### PR TITLE
feat(llm): provider-agnostic client + ask.py end-to-end demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ REDIS_URL="redis://localhost:6379/0"
 # A real sentence-transformer wrapper lands in Phase 3.
 # EMBEDDING_BACKEND=deterministic
 
+# LLM provider for the agent layer. 'echo' is an offline stub; 'anthropic'
+# calls the real API and requires ANTHROPIC_API_KEY.
+# LLM_BACKEND=echo
+# LLM_MODEL=claude-sonnet-4-5
+# ANTHROPIC_API_KEY=sk-ant-...
+
 # LLM providers — populated in later phases.
 # OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ All notable changes to this project will be documented in this file. The format 
 - `alphamind.retrieval.search` package: BM25 (`lexical_search`), pgvector cosine ANN (`dense_search`), Reciprocal Rank Fusion (`reciprocal_rank_fusion`), a `Reranker` protocol with a `DeterministicReranker` Jaccard stub, and the end-to-end `HybridSearch` orchestrator. The `as_of` time-horizon parameter is required at every stage that touches the database.
 - ADR 0005 documenting the retrieval pipeline design and the three-layer enforcement of the time-horizon invariant.
 - Runbook `docs/runbooks/retrieval.md` covering chunker / embedder / search invocation and failure modes.
+- `alphamind.llm` package: narrow `LLMClient` Protocol, `AnthropicLLMClient` adapter wrapping the official SDK with tenacity retries on transient errors and clean error mapping into `LLMClientError`, and an `EchoLLMClient` stub for offline development. Config-driven factory (`LLM_BACKEND`).
+- `scripts/ask.py` — the project's first end-to-end demo. Runs BM25 search over `filing_chunks`, formats the top-k chunks as numbered sources, and asks the LLM to answer using only those sources with citations. `--as-of` is required, not optional.
+- ADR 0006 documenting the LLM provider integration design.
+- Runbook `docs/runbooks/ask.md` covering the new CLI's invocation and failure modes.
 
 ### Changed
 - `EdgarClient` no longer sends a fixed `Accept: application/json` header — the same client now hits both JSON endpoints under `data.sec.gov` and HTML/XML bodies under `www.sec.gov/Archives`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ Once services are up and migrations applied, pull recent filings for a few ticke
 uv run python scripts/ingest_edgar.py --ticker AAPL MSFT NVDA
 ```
 
+### Asking a question
+
+After bodies are fetched (`--with-bodies`) and chunks are built, run:
+
+```bash
+LLM_BACKEND=anthropic ANTHROPIC_API_KEY=sk-ant-... \
+  uv run python scripts/ask.py \
+    --query "what is NVDA saying about China revenue concentration?" \
+    --as-of 2024-12-31
+```
+
+This is the first end-to-end demo — BM25 retrieval over your ingested filings + a Claude call that's instructed to answer using only the cited sources. Without an API key set, the default `LLM_BACKEND=echo` returns a stub so the rest of the pipeline can still be exercised. Operational details in [`docs/runbooks/ask.md`](docs/runbooks/ask.md).
+
 Example output:
 
 ```
@@ -87,7 +100,7 @@ CIK          TICKER     SEEN  WRITTEN  NAME
 
 - [x] Phase 1 — repo scaffolding, Postgres + pgvector, SEC EDGAR metadata ingestion
 - [x] Phase 2 — filing-body ingestion, finance-aware chunking, embeddings, hybrid retrieval (BM25 + pgvector + RRF + cross-encoder rerank) with a hard time-horizon filter at every stage
-- [ ] Phase 3 — real sentence-transformer embedder + cross-encoder rerank, LangGraph agent team (router, specialists, synthesizer, critic)
+- [ ] Phase 3 — LLM provider integration (Anthropic adapter shipped), real sentence-transformer embedder + cross-encoder rerank, LangGraph agent team (router, specialists, synthesizer, critic)
 - [ ] Phase 4 — fine-tuned SLM on financial text (LoRA / QLoRA)
 - [ ] Phase 5 — FastAPI serving layer with streaming, caching, cost routing
 - [ ] Phase 6 — backtest harness, evaluation set, public result dashboard

--- a/docs/adr/0006-llm-provider-integration.md
+++ b/docs/adr/0006-llm-provider-integration.md
@@ -1,0 +1,100 @@
+# 6. LLM provider integration
+
+- **Status**: accepted
+- **Date**: 2026-05-08
+
+## Context
+
+Phase 3 needs the agent layer to call a frontier LLM. Two design points
+matter:
+
+1. Agents shouldn't depend on a specific provider's SDK quirks. The
+   router, specialists, synthesizer, and critic all need to call
+   ``client.complete(messages)`` and not care whether the bytes go to
+   Anthropic, OpenAI, or a self-hosted model.
+2. Tests and offline development need to run end-to-end without an API
+   key. CI can't hit a paid endpoint on every PR.
+
+## Decision
+
+A narrow ``LLMClient`` Protocol with two attributes:
+
+- ``default_model: str``
+- ``async complete(messages, *, model, max_tokens, temperature, system) -> LLMResponse``
+
+Concrete implementations:
+
+| Backend | Class | Use case |
+| --- | --- | --- |
+| Anthropic | ``AnthropicLLMClient`` | Production. Wraps ``anthropic.AsyncAnthropic``. |
+| Echo | ``EchoLLMClient`` | Tests, offline dev. Returns ``"echo: <last user message>"``. |
+
+The factory in ``alphamind.llm.factory`` reads ``LLM_BACKEND`` from
+config and returns a singleton. ``LLM_BACKEND=echo`` is the default —
+the project boots and runs end-to-end without an API key, same as the
+deterministic embedder and reranker.
+
+### Why a thin wrapper around the SDK
+
+Two specific responsibilities live in the wrapper, not in agent code:
+
+1. **Provider quirks.** Anthropic takes ``system`` as a top-level
+   parameter, separate from the messages array. OpenAI folds it into
+   the messages array. ``LLMClient.complete`` takes ``system`` as a
+   keyword argument and each adapter handles the wiring. Without this,
+   every agent node would have provider-specific branching.
+2. **Retries and error mapping.** Tenacity wraps ``messages.create``
+   with exponential backoff on the documented retryable errors
+   (``RateLimitError``, ``APIConnectionError``, ``APITimeoutError``,
+   ``InternalServerError``). Non-retryable ``APIError`` is wrapped in
+   ``LLMClientError`` so call sites only need to catch one exception
+   type.
+
+### Why ``Message`` is a frozen dataclass and not a Pydantic model
+
+Three reasons:
+
+- The protocol is provider-agnostic; we want a transport that's
+  trivially serialisable but not tied to a particular validator.
+- Pydantic validation overhead matters when you're constructing
+  thousands of messages per second (which the agent graph will, once
+  it's parallel).
+- A frozen dataclass is the simplest way to enforce immutability —
+  agent code passes message lists around and shouldn't be mutating
+  them mid-conversation.
+
+### Why ``EchoLLMClient`` instead of mocking the API at every call site
+
+Same reason ``DeterministicHashEmbedder`` exists. Tests need a
+deterministic transport that satisfies the Protocol. Mocking
+``anthropic.AsyncAnthropic`` everywhere bloats test setup and couples
+test code to SDK shape. Echo is one ~30-line class that returns
+predictable output and counts tokens crudely so the accounting code in
+the agent graph still has something to track.
+
+### What's not covered yet
+
+- **Streaming.** ``messages.create(stream=True)`` returns an async
+  iterator of events. Streaming matters when the FastAPI serving layer
+  is in place (Phase 5). Out of scope for this PR.
+- **Tool use.** Anthropic's tool-calling protocol is the natural way to
+  let the agent layer query the retrieval pipeline. Lands when the
+  agent graph itself does (next slice of Phase 3).
+- **Cost tracking.** ``LLMResponse`` already carries ``input_tokens``
+  and ``output_tokens``; an aggregator that sums them across a run
+  lands when we have something to budget against.
+- **Other providers.** OpenAI, Gemini, self-hosted via vLLM. The
+  protocol allows them; nobody needs them yet, so they aren't built.
+
+## Consequences
+
+- Every agent node, every prompt template, every part of the synthesis
+  layer depends on the Protocol, not on the SDK. Swapping providers is
+  a config change.
+- Tests stay fast and deterministic. CI doesn't pay for API calls.
+- Offline development works — set ``LLM_BACKEND=echo`` and exercise
+  the full agent graph without an API key.
+- ``scripts/ask.py`` becomes the first end-to-end demo of the project:
+  BM25 search → cited prompt → real LLM answer. With
+  ``LLM_BACKEND=anthropic`` and a key set, this is the first thing in
+  the project that does what AlphaMind is for.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@ An ADR starts in `proposed` status, moves to `accepted` when merged, and may lat
 - [0003 — SEC EDGAR ingestion design](0003-edgar-ingestion-design.md)
 - [0004 — Storage layer for filing bodies](0004-storage-layer-for-filing-bodies.md)
 - [0005 — Retrieval pipeline: chunker, embedder, hybrid search](0005-retrieval-pipeline-design.md)
+- [0006 — LLM provider integration](0006-llm-provider-integration.md)

--- a/docs/runbooks/ask.md
+++ b/docs/runbooks/ask.md
@@ -1,0 +1,95 @@
+# Runbook — `scripts/ask.py`
+
+The first end-to-end demo of the project. Combines BM25 search over
+already-chunked filings with a real LLM call to produce a cited answer
+to a research question.
+
+## What it does
+
+```
+question + as-of date  →  BM25 search over filing_chunks  →
+                          top-k chunks formatted as numbered sources  →
+                          system prompt + cited-source rules  →
+                          LLM (Anthropic or echo stub)  →
+                          stdout: answer + source list + cost line
+```
+
+## Prerequisites
+
+- Phase 1 metadata ingest run for at least one ticker.
+- Phase 1 body ingest run (`--with-bodies`).
+- Phase 2 chunking run for the same filings (`chunk_filings_for_cik`).
+- `.env` with valid `DATABASE_URL` / `REDIS_URL` / `SEC_USER_AGENT`.
+
+To get real (non-echo) answers:
+
+```env
+LLM_BACKEND=anthropic
+LLM_MODEL=claude-sonnet-4-5
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Default is `LLM_BACKEND=echo` — the script runs without an API key, but
+output will be the echo stub repeating your question back.
+
+## Common invocations
+
+Ask about NVDA's most recent China-revenue commentary, time-bounded to
+end of 2024:
+
+```bash
+uv run python scripts/ask.py \
+  --query "What is NVDA saying about China revenue concentration?" \
+  --as-of 2024-12-31
+```
+
+Wider question across whatever you've ingested, more sources:
+
+```bash
+uv run python scripts/ask.py \
+  --query "What inventory write-down language has appeared this year?" \
+  --as-of 2025-04-30 \
+  --top-k 12
+```
+
+## Reading the output
+
+```
+[short answer paragraph]
+
+[longer reasoning section that walks through specific sources]
+
+Sources
+-------
+[1] NVDA  10-K  2024-02-21  accession=0001045810-24-000029  section='Item 1A. Risk Factors'
+[2] NVDA  10-Q  2024-08-28  accession=0001045810-24-000200  section='Item 7. MD&A'
+...
+
+[claude-sonnet-4-5  in=4123  out=412  stop=end_turn]
+```
+
+The bracketed last line is the cost-tracking footer: model, input
+tokens, output tokens, stop reason. Useful for keeping a running sense
+of spend.
+
+## Failure modes
+
+| Symptom | Likely cause | Action |
+| --- | --- | --- |
+| `No chunks matched.` | No filings chunked yet, or the as-of date predates them all | Run `chunk_filings_for_cik` first; widen `--as-of` |
+| `LLM call failed: anthropic api error: ...` | Bad API key, exhausted quota, or transient outage | Check `ANTHROPIC_API_KEY`; the wrapper already retries 4× on transient errors |
+| Output is `echo: <your question>` | `LLM_BACKEND=echo` (the default) | Set `LLM_BACKEND=anthropic` and supply `ANTHROPIC_API_KEY` |
+| Citations don't match the sources | LLM hallucinated a number; this is a known failure mode of every LLM-citation system | The critic agent (next phase) is the systematic fix; for now, manually verify each citation against the printed source list |
+
+## Operational notes
+
+- The `--as-of` date is required, not optional. Defaulting it to today
+  would silently let lookahead bias creep into historical questions —
+  the project's single most important correctness invariant.
+- BM25 retrieval is used (not hybrid). Dense retrieval requires real
+  embeddings, which are still on the deterministic stub. Once the real
+  embedder lands, switching to `HybridSearch` is a one-line change in
+  this script.
+- Every printed answer is a synthesis of LLM output. **Verify every
+  citation against the source list before quoting it elsewhere.**
+  LLM-generated citations have non-zero hallucination rate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "tiktoken>=0.8",
     "pgvector>=0.3",
     "numpy>=1.26",
+    "anthropic>=0.40",
 ]
 
 [dependency-groups]

--- a/scripts/ask.py
+++ b/scripts/ask.py
@@ -1,0 +1,213 @@
+"""Ask a research question grounded in already-ingested SEC filings.
+
+Usage:
+
+    uv run python scripts/ask.py \
+        --query "what is NVDA saying about China revenue concentration?" \
+        --as-of 2024-12-31
+
+The script runs a BM25 search over ``filing_chunks`` filtered by the
+as-of date, builds a prompt that lists each retrieved chunk as a
+numbered source, and calls the configured LLM. The model is instructed
+to answer using only the supplied sources and to cite by number.
+
+Defaults:
+
+- 8 retrieved chunks (override with ``--top-k``).
+- Date filter required — no default for the time horizon, on purpose
+  (see ADR 0005). A backtest at horizon 2023-06 that accidentally
+  retrieves chunks from 2024 silently produces alpha that didn't
+  exist; making ``--as-of`` mandatory turns that footgun off.
+
+To get real answers (not echoes), set:
+
+    LLM_BACKEND=anthropic
+    ANTHROPIC_API_KEY=sk-ant-...
+
+The default ``LLM_BACKEND=echo`` exists so the rest of the pipeline can
+be exercised without API costs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from datetime import date, datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from alphamind.config import get_settings
+from alphamind.db.session import dispose_engine, session_scope
+from alphamind.llm import LLMClientError, SystemMessage, UserMessage
+from alphamind.llm.factory import get_llm_client
+from alphamind.models.filing import Filing
+from alphamind.models.filing_chunk import FilingChunk
+from alphamind.retrieval.search.lexical import lexical_search
+
+logger = logging.getLogger("alphamind.ask")
+
+DEFAULT_TOP_K = 8
+
+SYSTEM_PROMPT = """\
+You are a research assistant for institutional equity analysis.
+
+Rules:
+1. Answer using ONLY the numbered sources provided. If the sources do
+   not contain enough information, say so plainly.
+2. Cite every claim with the source number in square brackets, e.g. [3].
+   Multiple citations look like [1][4].
+3. Do not speculate. Do not introduce facts that aren't in the sources.
+4. Quote sparingly. Paraphrase in your own voice.
+5. Output two sections: a short answer (2-4 sentences) and a longer
+   reasoning section that walks through the key sources.
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--query",
+        required=True,
+        help="The research question.",
+    )
+    parser.add_argument(
+        "--as-of",
+        required=True,
+        help="Time horizon (YYYY-MM-DD). No filings dated after this are used.",
+        type=lambda s: datetime.strptime(s, "%Y-%m-%d").date(),
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=DEFAULT_TOP_K,
+        help=f"Number of source chunks to feed the LLM (default: {DEFAULT_TOP_K}).",
+    )
+    return parser.parse_args()
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=get_settings().log_level,
+        format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+async def _hydrate_chunks(
+    chunk_ids: list[int],
+    *,
+    as_of: date,
+) -> list[FilingChunk]:
+    """Load chunks + parent filings + companies in one query."""
+    if not chunk_ids:
+        return []
+    async with session_scope() as session:
+        stmt = (
+            select(FilingChunk)
+            .where(FilingChunk.id.in_(chunk_ids))
+            .where(FilingChunk.filing_date <= as_of)
+            .options(selectinload(FilingChunk.filing).selectinload(Filing.company))
+        )
+        result = await session.execute(stmt)
+        chunks = list(result.scalars())
+    # Preserve the lexical-search ranking.
+    order = {cid: i for i, cid in enumerate(chunk_ids)}
+    chunks.sort(key=lambda c: order.get(c.id, len(order)))
+    return chunks
+
+
+def _format_sources(chunks: list[FilingChunk]) -> str:
+    """Build the [1]/[2]/... source block for the prompt."""
+    lines: list[str] = []
+    for i, chunk in enumerate(chunks, start=1):
+        ticker = chunk.filing.company.ticker or chunk.filing.company.cik
+        section = chunk.section or "—"
+        header = (
+            f"[{i}] {ticker} — {chunk.filing.form} — "
+            f"{chunk.filing.filing_date.isoformat()} — {section}"
+        )
+        lines.append(header)
+        lines.append(chunk.text)
+        lines.append("")  # blank line between sources
+    return "\n".join(lines).rstrip()
+
+
+def _print_sources(chunks: list[FilingChunk]) -> None:
+    print()
+    print("Sources")
+    print("-------")
+    for i, chunk in enumerate(chunks, start=1):
+        ticker = chunk.filing.company.ticker or chunk.filing.company.cik
+        section = chunk.section or "—"
+        print(
+            f"[{i}] {ticker}  {chunk.filing.form}  "
+            f"{chunk.filing.filing_date.isoformat()}  "
+            f"accession={chunk.filing.accession_number}  section={section!r}"
+        )
+
+
+async def _run(args: argparse.Namespace) -> int:
+    _configure_logging()
+
+    async with session_scope() as session:
+        hits = await lexical_search(
+            session,
+            query=args.query,
+            as_of=args.as_of,
+            limit=args.top_k,
+        )
+
+    if not hits:
+        print(
+            f"No chunks matched. Confirm filings are ingested + chunked, "
+            f"and that filing_date <= {args.as_of} for at least one filing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    chunks = await _hydrate_chunks([h.chunk_id for h in hits], as_of=args.as_of)
+    if not chunks:
+        print("Hydration returned no chunks (concurrent deletion?).", file=sys.stderr)
+        return 1
+
+    sources_block = _format_sources(chunks)
+    prompt = (
+        f"Question: {args.query}\n"
+        f"As-of date: {args.as_of.isoformat()}\n\n"
+        f"Sources:\n\n{sources_block}\n"
+    )
+
+    client = get_llm_client()
+    try:
+        response = await client.complete(
+            [SystemMessage(SYSTEM_PROMPT), UserMessage(prompt)],
+            max_tokens=1024,
+        )
+    except LLMClientError as exc:
+        print(f"LLM call failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(response.content.rstrip())
+    _print_sources(chunks)
+    print()
+    print(
+        f"[{response.model}  in={response.input_tokens}  out={response.output_tokens}  "
+        f"stop={response.stop_reason}]"
+    )
+    return 0
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        code = asyncio.run(_run(args))
+    finally:
+        asyncio.run(dispose_engine())
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/alphamind/config.py
+++ b/src/alphamind/config.py
@@ -18,6 +18,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 Environment = Literal["development", "test", "staging", "production"]
 StorageBackend = Literal["local"]
 EmbeddingBackend = Literal["deterministic"]
+LLMBackend = Literal["anthropic", "echo"]
 
 
 class Settings(BaseSettings):
@@ -77,6 +78,24 @@ class Settings(BaseSettings):
         ),
     )
 
+    # --- LLM provider ---
+    llm_backend: LLMBackend = Field(
+        default="echo",
+        description=(
+            "LLM backend used by alphamind.llm. 'anthropic' calls the real "
+            "API; 'echo' is a deterministic stub that echoes the last user "
+            "message back, useful for offline development and tests."
+        ),
+    )
+    llm_model: str = Field(
+        default="claude-sonnet-4-5",
+        description="Model identifier passed to the LLM backend.",
+    )
+    anthropic_api_key: str | None = Field(
+        default=None,
+        description="Required when llm_backend='anthropic'. Read from ANTHROPIC_API_KEY.",
+    )
+
     @property
     def is_production(self) -> bool:
         return self.environment == "production"
@@ -92,6 +111,7 @@ def get_settings() -> Settings:
 __all__ = [
     "EmbeddingBackend",
     "Environment",
+    "LLMBackend",
     "Settings",
     "StorageBackend",
     "get_settings",

--- a/src/alphamind/llm/__init__.py
+++ b/src/alphamind/llm/__init__.py
@@ -1,0 +1,41 @@
+"""LLM provider integration.
+
+The :class:`LLMClient` Protocol is the only thing call sites depend on —
+agent nodes, the synthesizer, the critic. Concrete implementations:
+
+- :class:`AnthropicLLMClient` — wraps the Anthropic Python SDK; the
+  default in production.
+- :class:`EchoLLMClient` — deterministic stub for tests and offline
+  development. Echoes the last user message back.
+
+The factory :func:`get_llm_client` reads ``LLM_BACKEND`` from config and
+returns a singleton. Swapping providers is a config change.
+"""
+
+from __future__ import annotations
+
+from alphamind.llm.anthropic import AnthropicLLMClient
+from alphamind.llm.base import (
+    AssistantMessage,
+    LLMClient,
+    LLMClientError,
+    LLMResponse,
+    Message,
+    SystemMessage,
+    UserMessage,
+)
+from alphamind.llm.echo import EchoLLMClient
+from alphamind.llm.factory import get_llm_client
+
+__all__ = [
+    "AnthropicLLMClient",
+    "AssistantMessage",
+    "EchoLLMClient",
+    "LLMClient",
+    "LLMClientError",
+    "LLMResponse",
+    "Message",
+    "SystemMessage",
+    "UserMessage",
+    "get_llm_client",
+]

--- a/src/alphamind/llm/anthropic.py
+++ b/src/alphamind/llm/anthropic.py
@@ -1,0 +1,145 @@
+"""Anthropic SDK adapter implementing :class:`LLMClient`.
+
+Wraps :class:`anthropic.AsyncAnthropic`. Two reasons to keep this thin:
+
+1. The protocol is what agent code depends on. The wrapper exists so
+   provider-specific quirks (Anthropic's separate ``system`` parameter,
+   its content-block response format) don't leak into call sites.
+2. Cost tracking and request retries belong here, not in every agent
+   node. Agents call ``complete``; this layer handles the rest.
+
+Retries: tenacity with exponential backoff on Anthropic's rate-limit
+errors. The SDK already retries some classes itself, but its defaults
+are conservative; we layer our own retry on top to cover the wider set
+of retryable errors observed in production.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+import anthropic
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from alphamind.llm.base import LLMClient, LLMClientError, LLMResponse, Message
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_MODEL = "claude-sonnet-4-5"
+DEFAULT_MAX_RETRIES = 4
+
+
+_RETRYABLE_EXCEPTIONS = (
+    anthropic.RateLimitError,
+    anthropic.APIConnectionError,
+    anthropic.APITimeoutError,
+    anthropic.InternalServerError,
+)
+
+
+class AnthropicLLMClient(LLMClient):
+    """Anthropic-backed implementation of :class:`LLMClient`."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        default_model: str = DEFAULT_MODEL,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        client: anthropic.AsyncAnthropic | None = None,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key must be non-empty")
+        self._client = client or anthropic.AsyncAnthropic(api_key=api_key)
+        self._default_model = default_model
+        self._max_retries = max_retries
+
+    @property
+    def default_model(self) -> str:
+        return self._default_model
+
+    async def complete(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str | None = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+        system: str | None = None,
+    ) -> LLMResponse:
+        if not messages:
+            raise ValueError("messages must be non-empty")
+
+        # Anthropic takes ``system`` as a top-level parameter, separate
+        # from the messages array. If the caller passed a system message
+        # inside ``messages``, lift it out so the SDK is happy.
+        api_messages: list[dict[str, str]] = []
+        sys_buffer: list[str] = [system] if system else []
+
+        for msg in messages:
+            if msg.role == "system":
+                sys_buffer.append(msg.content)
+            else:
+                api_messages.append({"role": msg.role, "content": msg.content})
+
+        if not api_messages:
+            raise ValueError("messages must contain at least one user/assistant turn")
+
+        api_system = "\n\n".join(s for s in sys_buffer if s)
+
+        # Build kwargs dict so we can omit ``system`` entirely when empty —
+        # the SDK's default sentinel is ``anthropic.Omit``, and passing
+        # ``None`` or ``""`` would still send the field.
+        create_kwargs: dict[str, object] = {
+            "model": model or self._default_model,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "messages": api_messages,
+        }
+        if api_system:
+            create_kwargs["system"] = api_system
+
+        retryer = retry(
+            stop=stop_after_attempt(self._max_retries),
+            wait=wait_exponential(multiplier=1, min=1, max=30),
+            retry=retry_if_exception_type(_RETRYABLE_EXCEPTIONS),
+            reraise=True,
+        )
+
+        @retryer
+        async def _do() -> anthropic.types.Message:
+            # The kwargs dict is typed dict[str, object] for ergonomic
+            # construction (we conditionally include ``system``), but the
+            # SDK's ``create`` is fully typed via overloads. Splatting a
+            # generic dict trips the overload selector even though every
+            # value is the right shape — silence at the call site rather
+            # than copy the SDK's typed-param dance into our wrapper.
+            result: anthropic.types.Message = (
+                await self._client.messages.create(**create_kwargs)  # type: ignore[call-overload]
+            )
+            return result
+
+        try:
+            response = await _do()
+        except anthropic.APIError as exc:
+            raise LLMClientError(f"anthropic api error: {exc}") from exc
+
+        # Anthropic returns content as a list of blocks; we want the first
+        # text block's text. Tool-use blocks land in later phases.
+        text_parts = [block.text for block in response.content if block.type == "text"]
+        content = "".join(text_parts)
+
+        return LLMResponse(
+            content=content,
+            model=response.model,
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+            stop_reason=response.stop_reason,
+        )

--- a/src/alphamind/llm/base.py
+++ b/src/alphamind/llm/base.py
@@ -1,0 +1,95 @@
+"""LLM client protocol + message types shared by every backend."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal, Protocol, runtime_checkable
+
+Role = Literal["system", "user", "assistant"]
+
+
+class LLMClientError(RuntimeError):
+    """Raised when the LLM backend returns a non-recoverable error."""
+
+
+@dataclass(frozen=True, slots=True)
+class Message:
+    """A single chat message.
+
+    ``role`` is ``"system"``, ``"user"``, or ``"assistant"``. Backends that
+    fold ``system`` into a separate parameter (Anthropic) take care of that
+    internally.
+    """
+
+    role: Role
+    content: str
+
+    def __post_init__(self) -> None:
+        if self.role not in ("system", "user", "assistant"):
+            raise ValueError(f"invalid role: {self.role!r}")
+
+
+def SystemMessage(content: str) -> Message:  # noqa: N802 — intentionally constructor-like
+    return Message(role="system", content=content)
+
+
+def UserMessage(content: str) -> Message:  # noqa: N802
+    return Message(role="user", content=content)
+
+
+def AssistantMessage(content: str) -> Message:  # noqa: N802
+    return Message(role="assistant", content=content)
+
+
+@dataclass(frozen=True, slots=True)
+class LLMResponse:
+    """A single completion."""
+
+    content: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    stop_reason: str | None
+
+
+@runtime_checkable
+class LLMClient(Protocol):
+    """A minimal chat-completion surface.
+
+    Implementations must be safe to call concurrently. The protocol covers
+    the workflows AlphaMind needs today:
+
+    - One-shot completion of a chat history.
+
+    Streaming and tool-calling extend the surface and land in later
+    phases when the agent graph needs them.
+    """
+
+    @property
+    def default_model(self) -> str:
+        """Model identifier used when ``complete()`` is called without ``model``."""
+        ...
+
+    async def complete(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str | None = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+        system: str | None = None,
+    ) -> LLMResponse:
+        """Run a chat completion.
+
+        Parameters
+        ----------
+        messages:
+            Conversation history. Backends that don't support a separate
+            ``system`` parameter prepend it as a system-role message.
+        system:
+            Optional system prompt. Provider-specific handling — Anthropic
+            takes it as a top-level field; OpenAI etc. fold it into the
+            messages array.
+        """
+        ...

--- a/src/alphamind/llm/echo.py
+++ b/src/alphamind/llm/echo.py
@@ -1,0 +1,55 @@
+"""Deterministic echo client for tests and offline development.
+
+Echoes the last user message back as the assistant response. Useless for
+real reasoning, useful for letting the agent graph and CLI run end-to-
+end without an Anthropic API key. Same role as the deterministic
+embedder: lets the pipeline be exercised without external services.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alphamind.llm.base import LLMResponse, Message
+
+
+class EchoLLMClient:
+    """Returns ``"echo: <last user message>"`` as the assistant reply."""
+
+    DEFAULT_MODEL = "echo-stub-1"
+
+    def __init__(self, *, default_model: str = DEFAULT_MODEL) -> None:
+        self._default_model = default_model
+
+    @property
+    def default_model(self) -> str:
+        return self._default_model
+
+    async def complete(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str | None = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+        system: str | None = None,
+    ) -> LLMResponse:
+        if not messages:
+            raise ValueError("messages must be non-empty")
+
+        last_user = next(
+            (m.content for m in reversed(messages) if m.role == "user"),
+            "",
+        )
+        content = f"echo: {last_user}"
+
+        # Approximate token counts as 1 token per 4 characters. Useless for
+        # billing but lets accounting code in the agent graph run.
+        prompt_chars = sum(len(m.content) for m in messages) + len(system or "")
+        return LLMResponse(
+            content=content,
+            model=model or self._default_model,
+            input_tokens=prompt_chars // 4,
+            output_tokens=len(content) // 4,
+            stop_reason="end_turn",
+        )

--- a/src/alphamind/llm/factory.py
+++ b/src/alphamind/llm/factory.py
@@ -1,0 +1,35 @@
+"""Factory that returns the configured LLM client as a singleton."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from alphamind.config import get_settings
+from alphamind.llm.anthropic import AnthropicLLMClient
+from alphamind.llm.base import LLMClient, LLMClientError
+from alphamind.llm.echo import EchoLLMClient
+
+
+@lru_cache(maxsize=1)
+def get_llm_client() -> LLMClient:
+    """Return the process-wide LLM client instance."""
+
+    settings = get_settings()
+    backend = settings.llm_backend.lower()
+
+    if backend == "echo":
+        return EchoLLMClient(default_model=settings.llm_model)
+
+    if backend == "anthropic":
+        api_key = settings.anthropic_api_key
+        if not api_key:
+            raise LLMClientError("ANTHROPIC_API_KEY is required when llm_backend='anthropic'")
+        return AnthropicLLMClient(
+            api_key=api_key,
+            default_model=settings.llm_model,
+        )
+
+    raise LLMClientError(f"unsupported llm backend: {backend!r}")
+
+
+__all__ = ["get_llm_client"]

--- a/tests/unit/llm/test_anthropic.py
+++ b/tests/unit/llm/test_anthropic.py
@@ -1,0 +1,171 @@
+"""Tests for the Anthropic LLM adapter.
+
+Uses a mocked ``anthropic.AsyncAnthropic`` client so no API key is needed
+and no network calls are made. We're testing the adapter wiring (system-
+message handling, response parsing, error mapping), not the SDK itself.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import anthropic
+import pytest
+
+from alphamind.llm.anthropic import AnthropicLLMClient
+from alphamind.llm.base import (
+    AssistantMessage,
+    LLMClientError,
+    SystemMessage,
+    UserMessage,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _fake_response(text: str = "stubbed answer") -> Any:
+    """Build a minimal duck-typed ``anthropic.types.Message``."""
+
+    class _Block:
+        type = "text"
+
+        def __init__(self, txt: str) -> None:
+            self.text = txt
+
+    class _Usage:
+        input_tokens = 42
+        output_tokens = 17
+
+    class _Msg:
+        model = "claude-sonnet-4-5"
+        stop_reason = "end_turn"
+
+        def __init__(self) -> None:
+            self.content = [_Block(text)]
+            self.usage = _Usage()
+
+    return _Msg()
+
+
+@pytest.fixture
+def mocked_client() -> tuple[anthropic.AsyncAnthropic, AsyncMock]:
+    """Returns (sdk_client, messages.create mock)."""
+    create_mock = AsyncMock(return_value=_fake_response())
+    sdk_client = AsyncMock(spec=anthropic.AsyncAnthropic)
+    sdk_client.messages = AsyncMock()
+    sdk_client.messages.create = create_mock
+    return sdk_client, create_mock
+
+
+async def test_complete_returns_parsed_response(
+    mocked_client: tuple[anthropic.AsyncAnthropic, AsyncMock],
+) -> None:
+    sdk_client, _ = mocked_client
+    client = AnthropicLLMClient(api_key="test-key", client=sdk_client)
+
+    response = await client.complete([UserMessage("hello")])
+
+    assert response.content == "stubbed answer"
+    assert response.input_tokens == 42
+    assert response.output_tokens == 17
+    assert response.stop_reason == "end_turn"
+
+
+async def test_lifts_system_messages_into_top_level_field(
+    mocked_client: tuple[anthropic.AsyncAnthropic, AsyncMock],
+) -> None:
+    sdk_client, create_mock = mocked_client
+    client = AnthropicLLMClient(api_key="test-key", client=sdk_client)
+
+    await client.complete(
+        [
+            SystemMessage("you are a research assistant"),
+            UserMessage("what's NVDA's q3 risk?"),
+            AssistantMessage("Here's a thought."),
+            UserMessage("be concise"),
+        ],
+        system="prepend this too",
+    )
+
+    kwargs = create_mock.call_args.kwargs
+    assert kwargs["system"] == "prepend this too\n\nyou are a research assistant"
+    # Only user/assistant messages remain in the messages array.
+    assert all(m["role"] in ("user", "assistant") for m in kwargs["messages"])
+    assert len(kwargs["messages"]) == 3
+
+
+async def test_uses_default_model_when_no_override(
+    mocked_client: tuple[anthropic.AsyncAnthropic, AsyncMock],
+) -> None:
+    sdk_client, create_mock = mocked_client
+    client = AnthropicLLMClient(
+        api_key="test-key",
+        default_model="claude-sonnet-4-5",
+        client=sdk_client,
+    )
+
+    await client.complete([UserMessage("hi")])
+
+    assert create_mock.call_args.kwargs["model"] == "claude-sonnet-4-5"
+
+
+async def test_passes_through_max_tokens_and_temperature(
+    mocked_client: tuple[anthropic.AsyncAnthropic, AsyncMock],
+) -> None:
+    sdk_client, create_mock = mocked_client
+    client = AnthropicLLMClient(api_key="test-key", client=sdk_client)
+
+    await client.complete(
+        [UserMessage("hi")],
+        max_tokens=512,
+        temperature=0.4,
+    )
+
+    kwargs = create_mock.call_args.kwargs
+    assert kwargs["max_tokens"] == 512
+    assert kwargs["temperature"] == 0.4
+
+
+async def test_rejects_empty_message_list() -> None:
+    client = AnthropicLLMClient(api_key="test-key", client=AsyncMock())
+    with pytest.raises(ValueError):
+        await client.complete([])
+
+
+async def test_rejects_messages_with_only_system_role(
+    mocked_client: tuple[anthropic.AsyncAnthropic, AsyncMock],
+) -> None:
+    sdk_client, _ = mocked_client
+    client = AnthropicLLMClient(api_key="test-key", client=sdk_client)
+
+    with pytest.raises(ValueError, match="user/assistant"):
+        await client.complete([SystemMessage("only system")])
+
+
+async def test_rejects_empty_api_key() -> None:
+    with pytest.raises(ValueError):
+        AnthropicLLMClient(api_key="")
+
+
+async def test_maps_sdk_apierror_to_llmclienterror(
+    mocked_client: tuple[anthropic.AsyncAnthropic, AsyncMock],
+) -> None:
+    sdk_client, create_mock = mocked_client
+
+    class _BadRequest(anthropic.BadRequestError):
+        def __init__(self) -> None:
+            pass
+
+        def __str__(self) -> str:
+            return "bad input"
+
+    create_mock.side_effect = _BadRequest()
+    client = AnthropicLLMClient(
+        api_key="test-key",
+        client=sdk_client,
+        max_retries=1,
+    )
+
+    with pytest.raises(LLMClientError, match="anthropic api error"):
+        await client.complete([UserMessage("hi")])

--- a/tests/unit/llm/test_echo.py
+++ b/tests/unit/llm/test_echo.py
@@ -1,0 +1,50 @@
+"""Tests for the echo LLM stub."""
+
+from __future__ import annotations
+
+import pytest
+
+from alphamind.llm import EchoLLMClient, LLMClient
+from alphamind.llm.base import (
+    AssistantMessage,
+    SystemMessage,
+    UserMessage,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_satisfies_protocol() -> None:
+    assert isinstance(EchoLLMClient(), LLMClient)
+
+
+async def test_echoes_last_user_message() -> None:
+    client = EchoLLMClient()
+
+    response = await client.complete(
+        [
+            SystemMessage("you are a research assistant"),
+            UserMessage("what's NVDA's q3 risk?"),
+            AssistantMessage("(thinking)"),
+            UserMessage("be concise"),
+        ]
+    )
+
+    assert response.content == "echo: be concise"
+    assert response.stop_reason == "end_turn"
+    assert response.input_tokens > 0
+    assert response.output_tokens > 0
+
+
+async def test_uses_provided_model_override() -> None:
+    client = EchoLLMClient(default_model="echo-default")
+
+    response = await client.complete([UserMessage("ping")], model="echo-custom")
+
+    assert response.model == "echo-custom"
+
+
+async def test_rejects_empty_message_list() -> None:
+    client = EchoLLMClient()
+    with pytest.raises(ValueError):
+        await client.complete([])

--- a/tests/unit/llm/test_messages.py
+++ b/tests/unit/llm/test_messages.py
@@ -1,0 +1,31 @@
+"""Tests for LLM message construction."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from alphamind.llm.base import (
+    AssistantMessage,
+    Message,
+    SystemMessage,
+    UserMessage,
+)
+
+
+def test_message_constructors_emit_correct_roles() -> None:
+    assert SystemMessage("hi").role == "system"
+    assert UserMessage("hi").role == "user"
+    assert AssistantMessage("hi").role == "assistant"
+
+
+def test_message_rejects_invalid_role() -> None:
+    with pytest.raises(ValueError):
+        Message(role="root", content="elevate me")  # type: ignore[arg-type]
+
+
+def test_message_is_frozen() -> None:
+    msg = UserMessage("hi")
+    with pytest.raises(FrozenInstanceError):
+        msg.content = "modified"  # type: ignore[misc]

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "anthropic" },
     { name = "asyncpg" },
     { name = "beautifulsoup4" },
     { name = "httpx" },
@@ -54,6 +55,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.14" },
+    { name = "anthropic", specifier = ">=0.40" },
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "httpx", specifier = ">=0.28" },
@@ -86,6 +88,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.100.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/2d/24caf0ff727cba2ed863925017c8f93463a2ea6224a0efe5626e672bc3d2/anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a", size = 758255, upload-time = "2026-05-06T15:07:13.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/c775c59ab9445ecabb57ef3d5c24027de060139189a9e312ef9ef889a665/anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d", size = 753596, upload-time = "2026-05-06T15:07:12.106Z" },
 ]
 
 [[package]]
@@ -401,6 +422,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -528,6 +567,96 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/1f/198ae537fccb7080a0ed655eb56abf64a92f79489dfbf79f40fa34225bcd/jiter-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7e791e247b8044512e070bd1f3633dc08350d32776d2d6e7473309d0edf256a2", size = 316896, upload-time = "2026-04-10T14:26:01.986Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/34/da67cff3fce964a36d03c3e365fb0f8726ade2a6cfd4d3c70107e216ead6/jiter-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71527ce13fd5a0c4e40ad37331f8c547177dbb2dd0a93e5278b6a5eecf748804", size = 321085, upload-time = "2026-04-10T14:26:03.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/36/4c72e67180d4e71a4f5dcf7886d0840e83c49ab11788172177a77570326e/jiter-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c4a7ab56f746014874f2c525584c0daca1dec37f66fd707ecef3b7e5c2228c", size = 347393, upload-time = "2026-04-10T14:26:05.314Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/db/9b39e09ceafa9878235c0fc29e3e3f9b12a4c6a98ea3085b998cadf3accc/jiter-0.14.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:376e9dafff914253bb9d46cdc5f7965607fbe7feb0a491c34e35f92b2770702e", size = 372937, upload-time = "2026-04-10T14:26:06.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/96/0dcba1d7a82c1b720774b48ef239376addbaf30df24c34742ac4a57b67b2/jiter-0.14.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:23ad2a7a9da1935575c820428dd8d2490ce4d23189691ce33da1fc0a58e14e1c", size = 463646, upload-time = "2026-04-10T14:26:08.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e3/f61b71543e746e6b8b805e7755814fc242715c16f1dba58e1cbccb8032c2/jiter-0.14.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b3ddf5786bc7732d293bba3411ac637ecfa200a39983166d1df86a59a43c9f", size = 380225, upload-time = "2026-04-10T14:26:10.161Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5e/0ddeb7096aca099114abe36c4921016e8d251e6f35f5890240b31f1f60ae/jiter-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c001d5a646c2a50dc055dd526dad5d5245969e8234d2b1131d0451e81f3a373", size = 358682, upload-time = "2026-04-10T14:26:11.574Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d1/fe0c46cd7fda9cad8f1ff9ad217dc61f1e4280b21052ec6dfe88c1446ef2/jiter-0.14.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:834bb5bdabca2e91592a03d373838a8d0a1b8bbde7077ae6913fd2fc51812d00", size = 359973, upload-time = "2026-04-10T14:26:13.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/21/f5317f91729b501019184771c80d60abd89907009e7bfa6c7e348c5bdd44/jiter-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4e9178be60e229b1b2b0710f61b9e24d1f4f8556985a83ff4c4f95920eea7314", size = 397568, upload-time = "2026-04-10T14:26:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/79d8f33fb2bf168db0df5c9cd16fe440a8ada57e929d3677b22712c2568f/jiter-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a7e4ccff04ec03614e62c613e976a3a5860dc9714ce8266f44328bdc8b1cab2c", size = 522535, upload-time = "2026-04-10T14:26:16.956Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/d1e3ff3d2a465e67f08507d74bafb2dcd29eba91dc939820e39e8dea38b8/jiter-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:69539d936fb5d55caf6ecd33e2e884de083ff0ea28579780d56c4403094bb8d9", size = 556709, upload-time = "2026-04-10T14:26:18.5Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/bbb2189f62ace8d95e869aa4c84c9946616f301e2d02895a6f20dcc3bba3/jiter-0.14.0-cp311-cp311-win32.whl", hash = "sha256:4927d09b3e572787cc5e0a5318601448e1ab9391bcef95677f5840c2d00eaa6d", size = 208660, upload-time = "2026-04-10T14:26:20.511Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/86/c500b53dcbf08575f5963e536ebd757a1f7c568272ba5d180b212c9a87fb/jiter-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:42d6ed359ac49eb922fdd565f209c57340aa06d589c84c8413e42a0f9ae1b842", size = 204659, upload-time = "2026-04-10T14:26:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/a676249049d42cb29bef82233e4fe0524d414cbe3606c7a4b311193c2f77/jiter-0.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:6dd689f5f4a5a33747b28686e051095beb214fe28cfda5e9fe58a295a788f593", size = 194772, upload-time = "2026-04-10T14:26:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a1/ef34ca2cab2962598591636a1804b93645821201cc0095d4a93a9a329c9d/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a25ffa2dbbdf8721855612f6dca15c108224b12d0c4024d0ac3d7902132b4211", size = 311366, upload-time = "2026-04-10T14:28:27.943Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/520576a532a6b8a6f42747afed289c8448c879a34d7802fe2c832d4fd38f/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ac9cbaa86c10996b92bd12c91659b60f939f8e28fcfa6bc11a0e90a774ce95b", size = 309873, upload-time = "2026-04-10T14:28:29.688Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7c/c16db114ea1f2f532f198aa8dc39585026af45af362c69a0492f31bc4821/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:844e73b6c56b505e9e169234ea3bdea2ea43f769f847f47ac559ba1d2361ebea", size = 344816, upload-time = "2026-04-10T14:28:31.348Z" },
+    { url = "https://files.pythonhosted.org/packages/99/8f/15e7741ff19e9bcd4d753f7ff22f988fd54592f134ca13701c13ea8c20e0/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e52c076f187405fc21523c746c04399c9af8ece566077ed147b2126f2bcba577", size = 351445, upload-time = "2026-04-10T14:28:33.093Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
 ]
 
 [[package]]
@@ -1428,6 +1557,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
First slice of Phase 3. Stacked on PR #11 — base will move to `main` once #11 merges.

## Why this PR exists

Until now the project could ingest filings, store bodies, chunk them, and run hybrid retrieval — but the LLM call was missing. Without it, none of that produces an actual answer to a research question. This adds the LLM provider integration plus a small CLI that ties retrieval and the LLM together end-to-end.

This is the first thing in the project that does what AlphaMind is *for*.

## Scope choice

I started this branch intending to wire the real sentence-transformer embedder and cross-encoder reranker. Hit a yak-shave: torch + transformers don't have wheels for macOS Intel anymore (the platform of the current dev box). Pivoted to LLM integration instead — works everywhere, higher leverage, unblocks the agent graph in the next slice.

Real ML model integration moves to a later PR where we can rely on Linux / Apple Silicon environments.

## What's in

### `alphamind.llm` package
- `LLMClient` Protocol — `default_model` + `complete(messages, *, model, max_tokens, temperature, system) -> LLMResponse`. The only thing agent code will depend on.
- `AnthropicLLMClient` — wraps `anthropic.AsyncAnthropic`. Lifts system messages into the SDK's top-level `system` parameter, layers tenacity retries on transient errors (`RateLimitError`, `APIConnectionError`, `APITimeoutError`, `InternalServerError`), and maps any other `APIError` into a single `LLMClientError` so call sites only catch one exception type.
- `EchoLLMClient` — returns `\"echo: <last user message>\"` with rough token counts. Same role as the deterministic embedder: lets the pipeline run end-to-end without an API key. The default backend.
- Config-driven factory: `LLM_BACKEND` (`echo` default, `anthropic` for prod), `LLM_MODEL`, `ANTHROPIC_API_KEY`.

### `scripts/ask.py`
End-to-end research-question CLI:

```bash
LLM_BACKEND=anthropic ANTHROPIC_API_KEY=sk-ant-... \\
  uv run python scripts/ask.py \\
    --query \"What is NVDA saying about China revenue concentration?\" \\
    --as-of 2024-12-31
```

Pipeline: BM25 search → top-k chunks formatted as numbered sources → system prompt enforcing source-grounded citation → LLM call → answer + source list + cost-tracking footer.

`--as-of` is **required, no default**. Defaulting it to today would silently let lookahead bias creep into historical questions — see ADR 0005 for why this is the project's most important correctness invariant. Same rule as `HybridSearch.search`.

BM25 is used (not hybrid retrieval) because dense retrieval still relies on the deterministic embedder stub. Switching to `HybridSearch` is a one-line change once the real embedder lands.

## Tests

90 unit tests pass (15 new, 75 from the Phase 2 slice this PR stacks on). All green locally:

- ruff: 0 issues
- ruff format: clean
- mypy strict: 71 source files, no issues
- pytest: 90 passed

LLM tests mock `anthropic.AsyncAnthropic` via `unittest.mock.AsyncMock`. No network calls, no API key needed in CI.

## Docs

- ADR 0006 — LLM provider integration design + rationale
- `docs/runbooks/ask.md` — prereqs, common invocations, output format, failure modes
- README `Asking a question` section + roadmap update
- CHANGELOG entries

## What's deferred

- **Real embedder + cross-encoder reranker** — environment-dependent on macOS Intel; lands when the dev environment is Linux/Apple Silicon or in CI itself.
- **Streaming** — `messages.create(stream=True)` matters for the FastAPI serving layer in Phase 5.
- **Tool use** — Anthropic's tool-calling protocol is the natural way to let agents query retrieval. Lands with the LangGraph graph in the next slice of Phase 3.
- **Cost aggregation** — `LLMResponse` already carries token counts; an aggregator that sums them across a run lands when there's a budget to enforce.
- **LangGraph agent team** — the chunky next slice of Phase 3.

## Verifying locally

```bash
make compose-up
make migrate
uv run python scripts/ingest_edgar.py --ticker AAPL --with-bodies --limit 3
# (chunk the filings via chunk_filings_for_cik — programmatic for now,
# CLI for chunking lands with the agent graph)
LLM_BACKEND=echo uv run python scripts/ask.py \\
  --query \"any risk factors about supply chain?\" \\
  --as-of 2024-12-31
```

Echo backend will print `echo: <your prompt>` — proves the wiring. Swap in real `LLM_BACKEND=anthropic` + a key for actual answers.