### PR TITLE
feat: phase 2 — chunking, embeddings, hybrid retrieval, rerank

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,17 @@ REDIS_URL="redis://localhost:6379/0"
 # STORAGE_BACKEND=local
 # STORAGE_LOCAL_PATH=./data/storage
 
+# Embedder backend. 'deterministic' is hash-based and model-free (good for
+# tests and dev). 'gemini' calls Google's free text-embedding-004 endpoint;
+# set GOOGLE_API_KEY to a key from https://aistudio.google.com/app/apikey.
+# EMBEDDER_BACKEND=deterministic
+# EMBEDDER_DIMENSION=768
+# GOOGLE_API_KEY=
+# GEMINI_EMBEDDING_MODEL=text-embedding-004
+
 # LLM providers — populated in later phases.
 # OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=
-# GOOGLE_API_KEY=
 
 # Market data — populated in later phases.
 # ALPACA_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,25 @@ All notable changes to this project will be documented in this file. The format 
 - `EdgarClient.get_primary_document()` for fetching filing bodies from EDGAR Archives, returning `(bytes, content_type, source_url)`.
 - `ingest_bodies_for_cik` service and `--with-bodies` CLI flag for `scripts/ingest_edgar.py`. Idempotent: refetched bodies whose SHA-256 matches the existing row skip the storage write and the upsert.
 - ADR 0004 documenting the storage layer design.
+- `alphamind.chunking` package: `parse_filing_html` walks leaf block elements (preserving inline-XBRL and styled spans within their containing paragraph), `detect_sections` groups paragraphs by `Item N` / `Part N` headings with table-of-contents deduplication, and `chunk_text` / `chunk_filing` produce paragraph-aware overlapping chunks under a character budget.
+- `FilingChunk` ORM model with migration `0004_filing_chunks`, storing per-document slices keyed on `(filing_document_id, chunk_index)` and tagged with `source_content_hash` so the service can detect stale chunks when a body changes.
+- `chunk_filing_document` and `chunk_bodies_for_cik` services: idempotent persistence reading bodies from the `StorageBackend`, replacing prior chunks under a SAVEPOINT so a single failure leaves prior successes intact.
+- `scripts/ingest_edgar.py` gains `--chunk` (implies `--with-bodies`) and `--force-chunk`, with a per-CIK summary table reporting documents seen, chunked, skipped, failed, and total chunks written.
+- `alphamind.embeddings` package with an `Embedder` protocol, a model-free `DeterministicEmbedder` (hash-based, L2-normalised, 384-dim by default) for tests and dev, and a config-driven `get_embedder` factory so a real backend can be swapped in without touching call sites.
+- `FilingChunk.embedding` (`vector(384)`), `embedding_model`, and `embedded_at` columns added via migration `0005_chunk_embeddings`, plus a partial index on `embedding_model` for cheap "needs re-embedding" lookups.
+- `embed_chunks_for_document` and `embed_chunks_for_cik` services: batched, idempotent re-embed-on-model-change, dimension-validated, SAVEPOINT-isolated per document.
+- `scripts/ingest_edgar.py` gains `--embed` (implies `--chunk`) and `--force-embed`, with a per-CIK summary reporting documents seen, failed, chunks embedded, and chunks skipped.
+- `embedder_backend` and `embedder_dimension` settings in `alphamind.config`.
+- `GeminiEmbedder`: real backend calling Google's `text-embedding-004` REST endpoint over httpx, with a token-bucket rate limiter (defaults to 20 req/s, well under the 1500 RPM free-tier ceiling), tenacity-based exponential-backoff retries on 429/5xx, transparent slicing into the 100-input `batchEmbedContents` cap, and an `aclose()` lifecycle for clean shutdown via `dispose_embedder()`.
+- Migration `0006_widen_embedding_to_768` resizes `filing_chunks.embedding` from `vector(384)` to `vector(768)` to match Gemini's output; the `DeterministicEmbedder` default dimension and `Settings.embedder_dimension` default move to 768 in lockstep.
+- `google_api_key` and `gemini_embedding_model` settings; ``.env.example`` documents the Google AI Studio workflow.
+- `alphamind.retrieval` package implementing hybrid search over filing chunks: `dense_search` (pgvector cosine ANN), `bm25_search` (`ts_rank_cd` over a generated `text_tsv` column), and `hybrid_search` (Reciprocal Rank Fusion of the two). All three accept the same filters: `as_of_date` (no filings dated after — required for honest backtests), `cik`, `form_types`, `section_labels`.
+- `RetrievalResult` dataclass carrying enough filing context (company, form, accession number, section, filing date) to cite a chunk without a second query, plus per-retriever ranks (`dense_rank`, `bm25_rank`) on hybrid results for debuggability.
+- Migration `0007_retrieval_indexes` adds a generated `text_tsv tsvector` column (`to_tsvector('english', text)`, STORED) with a GIN index, plus an HNSW index on `embedding` using `vector_cosine_ops`. Alembic env.py gains an `include_object` filter so autogenerate ignores the raw-SQL-managed objects.
+- `scripts/query.py` CLI: ad-hoc hybrid/dense/BM25 search with `--mode`, `--k`, `--cik`, `--form`, `--section`, and `--as-of` flags; prints company, form, accession, section, score, and per-retriever ranks for each hit.
+- `alphamind.reranking` package implementing cross-encoder reranking: a `Reranker` protocol, a `DeterministicReranker` (Jaccard overlap, model-free) for tests and dev, and a `CrossEncoderReranker` wrapping `sentence-transformers` behind the optional `rerank` extra (`uv sync --extra rerank`). `rerank_results` adapts a reranker onto a list of `RetrievalResult`, replacing the score and preserving the per-retriever ranks.
+- `scripts/query.py` gains `--rerank`; when set, it widens the retrieval candidate pool and applies the configured reranker before printing.
+- `reranker_backend` and `cross_encoder_model` settings in `alphamind.config`.
 
 ### Changed
 - `EdgarClient` no longer sends a fixed `Accept: application/json` header — the same client now hits both JSON endpoints under `data.sec.gov` and HTML/XML bodies under `www.sec.gov/Archives`.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,22 @@ CIK          TICKER     SEEN  WRITTEN  NAME
 
 `SEEN` is what EDGAR returned in the recent-filings window; `WRITTEN` is how many passed the form filter and got upserted. Operational details in [`docs/runbooks/ingest-edgar.md`](docs/runbooks/ingest-edgar.md).
 
+### Querying the corpus
+
+After bodies are ingested, chunked, and embedded:
+
+```bash
+uv run python scripts/ingest_edgar.py --ticker AAPL MSFT NVDA --embed --limit 5
+uv run python scripts/query.py "supply chain risk" --form 10-K --k 5
+uv run python scripts/query.py "ai chip demand" --rerank
+```
+
+`--mode` selects `hybrid` (RRF over dense + BM25, default), `dense`, or `bm25`. Filters: `--cik`, `--form`, `--section`, `--as-of YYYY-MM-DD`. `--rerank` widens the candidate pool and runs the configured cross-encoder over it (install with `uv sync --extra rerank` for the real model; the default `deterministic` reranker has no dependencies).
+
 ## Roadmap
 
 - [x] Phase 1 — repo scaffolding, Postgres + pgvector, SEC EDGAR metadata ingestion
-- [ ] Phase 2 — filing-body ingestion, chunking, embeddings, hybrid retrieval, cross-encoder rerank
+- [x] Phase 2 — filing-body ingestion, chunking, embeddings, hybrid retrieval, cross-encoder rerank
 - [ ] Phase 3 — LangGraph agent team (router, specialists, synthesizer, critic)
 - [ ] Phase 4 — fine-tuned SLM on financial text (LoRA / QLoRA)
 - [ ] Phase 5 — FastAPI serving layer with streaming, caching, cost routing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,17 @@ dependencies = [
     "redis>=5.2",
     "httpx>=0.28",
     "tenacity>=9.0",
+    "beautifulsoup4>=4.12",
+    "lxml>=5.3",
+    "pgvector>=0.3",
+]
+
+[project.optional-dependencies]
+# Pulls torch + sentence-transformers. Optional because torch is ~1GB and
+# the deterministic reranker is enough for tests and dev. Install with:
+#   uv sync --extra rerank
+rerank = [
+    "sentence-transformers>=3.0",
 ]
 
 [dependency-groups]
@@ -111,6 +122,21 @@ exclude = ["^src/alphamind/db/migrations/"]
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
+
+# pgvector ships SQLAlchemy types without a py.typed marker yet (the package
+# does include inline annotations). Silence the "missing stubs" error so the
+# narrow surface we touch (Vector) doesn't poison strict mode.
+[[tool.mypy.overrides]]
+module = "pgvector.*"
+ignore_missing_imports = true
+
+# sentence-transformers is an optional extra (see [project.optional-dependencies]
+# rerank). The CrossEncoderReranker imports it lazily inside a try/except and
+# raises RerankerError if it is not installed, so mypy without the extra should
+# not block — and shipping stubs for torch+transformers is impractical anyway.
+[[tool.mypy.overrides]]
+module = "sentence_transformers.*"
+ignore_missing_imports = true
 
 # -----------------------------------------------------------------------------
 # Pytest.

--- a/scripts/ingest_edgar.py
+++ b/scripts/ingest_edgar.py
@@ -6,6 +6,8 @@ Usage:
     uv run python scripts/ingest_edgar.py --cik 320193 789019 --forms 10-K 10-Q
     uv run python scripts/ingest_edgar.py --ticker AAPL --limit 5
     uv run python scripts/ingest_edgar.py --ticker AAPL --with-bodies
+    uv run python scripts/ingest_edgar.py --ticker AAPL --with-bodies --chunk
+    uv run python scripts/ingest_edgar.py --ticker AAPL --chunk --embed
 
 The script exits with code 1 if any ticker fails to resolve or any request
 raises. Per-item errors are logged but do not abort sibling items so that
@@ -15,6 +17,15 @@ When ``--with-bodies`` is set, each filing's primary document is fetched
 from EDGAR Archives, written to the configured storage backend, and
 recorded in the ``filing_documents`` table. Bodies whose SHA-256 already
 matches what is stored are skipped without rewriting.
+
+When ``--chunk`` is set, every persisted filing document for each CIK is
+read back from storage, split into retrieval-ready chunks, and inserted
+into ``filing_chunks``. Documents whose stored chunks already match the
+current body hash are skipped (use ``--force-chunk`` to re-chunk anyway).
+
+When ``--embed`` is set, every chunk that is missing an embedding (or was
+embedded under a different model) is encoded by the configured embedder
+and written back. ``--embed`` implies ``--chunk``.
 """
 
 from __future__ import annotations
@@ -23,9 +34,13 @@ import argparse
 import asyncio
 import logging
 import sys
+from dataclasses import dataclass
 
+from alphamind.chunking.service import ChunkBatchResult, chunk_bodies_for_cik
 from alphamind.config import get_settings
 from alphamind.db.session import dispose_engine
+from alphamind.embeddings.factory import dispose_embedder, get_embedder
+from alphamind.embeddings.service import EmbedBatchResult, embed_chunks_for_cik
 from alphamind.ingestion.edgar.client import EdgarClient
 from alphamind.ingestion.edgar.service import (
     BodyIngestResult,
@@ -34,6 +49,7 @@ from alphamind.ingestion.edgar.service import (
     ingest_cik,
     ingest_ticker,
 )
+from alphamind.storage.base import StorageBackend
 from alphamind.storage.factory import get_storage
 
 logger = logging.getLogger("alphamind.ingest_edgar")
@@ -69,6 +85,32 @@ def parse_args() -> argparse.Namespace:
             "body and persist it via the storage backend."
         ),
     )
+    parser.add_argument(
+        "--chunk",
+        action="store_true",
+        help=(
+            "After persisting bodies, chunk each filing document and write "
+            "rows to filing_chunks. Implies --with-bodies."
+        ),
+    )
+    parser.add_argument(
+        "--force-chunk",
+        action="store_true",
+        help="Re-chunk filings even when stored chunks match the current hash.",
+    )
+    parser.add_argument(
+        "--embed",
+        action="store_true",
+        help=(
+            "After chunking, encode each chunk with the configured embedder "
+            "and write vectors to filing_chunks. Implies --chunk."
+        ),
+    )
+    parser.add_argument(
+        "--force-embed",
+        action="store_true",
+        help="Re-embed chunks even when stored vectors match the current model.",
+    )
     return parser.parse_args()
 
 
@@ -86,78 +128,128 @@ def _build_form_filter(forms: list[str]) -> frozenset[str] | None:
     return frozenset(forms)
 
 
+@dataclass
+class _PipelineState:
+    """Mutable accumulators for the per-CIK pipeline."""
+
+    body_results: list[BodyIngestResult]
+    chunk_results: list[ChunkBatchResult]
+    embed_results: list[EmbedBatchResult]
+    exit_code: int = 0
+
+
+async def _process_bodies_and_chunks(
+    *,
+    client: EdgarClient,
+    storage: StorageBackend | None,
+    cik: str,
+    label: str,
+    forms: frozenset[str] | None,
+    args: argparse.Namespace,
+    state: _PipelineState,
+) -> None:
+    """Fetch and persist bodies for a CIK, then chunk them when requested.
+
+    ``label`` is the user-facing identifier (ticker or raw CIK) used in log
+    messages so failures can be traced back to the input that produced them.
+    """
+
+    if storage is None:
+        return
+
+    try:
+        state.body_results.append(
+            await ingest_bodies_for_cik(
+                client,
+                storage,
+                cik,
+                form_types=forms,
+                limit=args.limit,
+            )
+        )
+    except Exception:
+        logger.exception("body ingest failed for %s cik=%s", label, cik)
+        state.exit_code = 1
+        return
+
+    want_chunks = args.chunk or args.embed
+    if not want_chunks:
+        return
+
+    try:
+        state.chunk_results.append(
+            await chunk_bodies_for_cik(
+                storage,
+                cik,
+                form_types=forms,
+                limit=args.limit,
+                force=args.force_chunk,
+            )
+        )
+    except Exception:
+        logger.exception("chunking failed for %s cik=%s", label, cik)
+        state.exit_code = 1
+        return
+
+    if not args.embed:
+        return
+
+    try:
+        state.embed_results.append(
+            await embed_chunks_for_cik(
+                cik,
+                embedder=get_embedder(),
+                form_types=forms,
+                limit=args.limit,
+                force=args.force_embed,
+            )
+        )
+    except Exception:
+        logger.exception("embedding failed for %s cik=%s", label, cik)
+        state.exit_code = 1
+
+
 async def _run(args: argparse.Namespace) -> int:
     _configure_logging()
     forms = _build_form_filter(args.forms)
 
+    # --chunk and --embed both require persisted bodies upstream.
+    want_bodies = args.with_bodies or args.chunk or args.embed
+
     results: list[IngestResult] = []
-    body_results: list[BodyIngestResult] = []
-    exit_code = 0
-    storage = get_storage() if args.with_bodies else None
+    state = _PipelineState(body_results=[], chunk_results=[], embed_results=[])
+    storage = get_storage() if want_bodies else None
 
     async with EdgarClient() as client:
-        if args.ticker:
-            for ticker in args.ticker:
-                try:
-                    result = await ingest_ticker(
-                        client,
-                        ticker,
-                        form_types=forms,
-                        limit=args.limit,
-                    )
-                    results.append(result)
-                except Exception:
-                    logger.exception("ingest failed for ticker=%s", ticker)
-                    exit_code = 1
-                    continue
+        inputs = [(t, "ticker") for t in (args.ticker or [])]
+        inputs += [(c, "cik") for c in (args.cik or [])]
 
-                if storage is not None:
-                    try:
-                        body_results.append(
-                            await ingest_bodies_for_cik(
-                                client,
-                                storage,
-                                result.cik,
-                                form_types=forms,
-                                limit=args.limit,
-                            )
-                        )
-                    except Exception:
-                        logger.exception(
-                            "body ingest failed for ticker=%s cik=%s",
-                            ticker,
-                            result.cik,
-                        )
-                        exit_code = 1
-        elif args.cik:
-            for cik in args.cik:
-                try:
-                    result = await ingest_cik(
-                        client,
-                        cik,
-                        form_types=forms,
-                        limit=args.limit,
-                    )
-                    results.append(result)
-                except Exception:
-                    logger.exception("ingest failed for cik=%s", cik)
-                    exit_code = 1
-                    continue
+        for value, kind in inputs:
+            try:
+                if kind == "ticker":
+                    result = await ingest_ticker(client, value, form_types=forms, limit=args.limit)
+                else:
+                    result = await ingest_cik(client, value, form_types=forms, limit=args.limit)
+                results.append(result)
+            except Exception:
+                logger.exception("ingest failed for %s=%s", kind, value)
+                state.exit_code = 1
+                continue
 
-                if storage is not None:
-                    try:
-                        body_results.append(
-                            await ingest_bodies_for_cik(
-                                client,
-                                storage,
-                                result.cik,
-                                form_types=forms,
-                                limit=args.limit,
-                            )
-                        )
-                    except Exception:
-                        logger.exception("body ingest failed for cik=%s", result.cik)
-                        exit_code = 1
+            await _process_bodies_and_chunks(
+                client=client,
+                storage=storage,
+                cik=result.cik,
+                label=f"{kind}={value}",
+                forms=forms,
+                args=args,
+                state=state,
+            )
+
+    body_results = state.body_results
+    chunk_results = state.chunk_results
+    embed_results = state.embed_results
+    exit_code = state.exit_code
 
     print()
     print(f"{'CIK':<12} {'TICKER':<8} {'SEEN':>6} {'WRITTEN':>8}  NAME")
@@ -176,7 +268,35 @@ async def _run(args: argparse.Namespace) -> int:
                 f"{b.bodies_unchanged:>10} {b.bodies_failed:>7}"
             )
 
+    if chunk_results:
+        print()
+        print(
+            f"{'CIK':<12} {'DOCS_SEEN':>10} {'CHUNKED':>8} "
+            f"{'SKIPPED':>8} {'FAILED':>7} {'CHUNKS':>8}"
+        )
+        for c in chunk_results:
+            print(
+                f"{c.cik:<12} {c.documents_seen:>10} {c.documents_chunked:>8} "
+                f"{c.documents_skipped:>8} {c.documents_failed:>7} {c.chunks_written:>8}"
+            )
+
+    if embed_results:
+        print()
+        print(f"{'CIK':<12} {'DOCS_SEEN':>10} {'FAILED':>7} {'EMBEDDED':>9} {'SKIPPED':>8}")
+        for e in embed_results:
+            print(
+                f"{e.cik:<12} {e.documents_seen:>10} {e.documents_failed:>7} "
+                f"{e.chunks_embedded:>9} {e.chunks_skipped:>8}"
+            )
+
     return exit_code
+
+
+async def _shutdown() -> None:
+    """Close cached async resources before the event loop tears down."""
+
+    await dispose_embedder()
+    await dispose_engine()
 
 
 def main() -> None:
@@ -184,7 +304,7 @@ def main() -> None:
     try:
         code = asyncio.run(_run(args))
     finally:
-        asyncio.run(dispose_engine())
+        asyncio.run(_shutdown())
     sys.exit(code)
 
 

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -1,0 +1,205 @@
+"""Ad-hoc hybrid-search CLI over the ingested filing corpus.
+
+Usage:
+
+    uv run python scripts/query.py "what is the bull case for nvidia gpus" --k 5
+    uv run python scripts/query.py "supply chain risk" --form 10-K --as-of 2025-01-01
+    uv run python scripts/query.py "revenue guidance" --cik 320193 --mode dense
+    uv run python scripts/query.py "share buybacks" --mode bm25
+    uv run python scripts/query.py "ai chip demand" --rerank
+
+Results are printed in reading order with citation context — company,
+form, accession number, section, and a short text preview. ``--mode``
+defaults to ``hybrid``; pass ``dense`` or ``bm25`` to inspect either
+retriever in isolation. ``--rerank`` runs the configured cross-encoder
+over the candidate pool before printing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import textwrap
+from datetime import date
+
+from alphamind.config import get_settings
+from alphamind.db.session import dispose_engine, session_scope
+from alphamind.embeddings.factory import dispose_embedder, get_embedder
+from alphamind.reranking import dispose_reranker, get_reranker, rerank_results
+from alphamind.retrieval import (
+    DEFAULT_CANDIDATES,
+    DEFAULT_TOP_K,
+    RetrievalResult,
+    bm25_search,
+    dense_search,
+    hybrid_search,
+)
+
+logger = logging.getLogger("alphamind.query")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("query", help="Natural-language search query.")
+    parser.add_argument(
+        "--mode",
+        choices=("hybrid", "dense", "bm25"),
+        default="hybrid",
+        help="Which retriever to run. Default: hybrid (RRF over dense + BM25).",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=DEFAULT_TOP_K,
+        help=f"Number of results to return. Default: {DEFAULT_TOP_K}.",
+    )
+    parser.add_argument(
+        "--candidates",
+        type=int,
+        default=DEFAULT_CANDIDATES,
+        help=(f"Per-retriever candidate pool for hybrid mode. Default: {DEFAULT_CANDIDATES}."),
+    )
+    parser.add_argument(
+        "--cik",
+        default=None,
+        help="Restrict to a single CIK (10-digit; leading zeros optional).",
+    )
+    parser.add_argument(
+        "--form",
+        nargs="+",
+        default=None,
+        help="Restrict to specific form types (e.g. 10-K 10-Q).",
+    )
+    parser.add_argument(
+        "--section",
+        nargs="+",
+        default=None,
+        help="Restrict to specific section labels (e.g. item_1a item_7).",
+    )
+    parser.add_argument(
+        "--as-of",
+        type=date.fromisoformat,
+        default=None,
+        help="Drop filings dated after this YYYY-MM-DD (for honest backtests).",
+    )
+    parser.add_argument(
+        "--rerank",
+        action="store_true",
+        help=(
+            "Rerank the candidate pool with the configured reranker before "
+            "printing. Pulls more candidates than --k when used so the final "
+            "ordering has something to reshuffle."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=get_settings().log_level,
+        format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def _print_results(results: list[RetrievalResult], *, mode: str) -> None:
+    if not results:
+        print("(no results)")
+        return
+
+    print(f"\n{len(results)} result(s) [mode={mode}]\n")
+    for i, r in enumerate(results, start=1):
+        ranks = []
+        if r.dense_rank is not None:
+            ranks.append(f"dense#{r.dense_rank}")
+        if r.bm25_rank is not None:
+            ranks.append(f"bm25#{r.bm25_rank}")
+        rank_str = f" ({', '.join(ranks)})" if ranks else ""
+
+        header = (
+            f"[{i}] {r.ticker or '-':<6} {r.form:<6} "
+            f"{r.filing_date.isoformat()} {r.accession_number} "
+            f"§ {r.section_label} score={r.score:.4f}{rank_str}"
+        )
+        print(header)
+        preview = textwrap.shorten(r.text.replace("\n", " "), width=220, placeholder=" …")
+        print(f"    {preview}\n")
+
+
+async def _run(args: argparse.Namespace) -> int:
+    _configure_logging()
+    form_types = frozenset(args.form) if args.form else None
+    section_labels = frozenset(args.section) if args.section else None
+
+    # When reranking we want a wider candidate pool than ``--k`` so the
+    # reranker has room to reorder — otherwise it can only confirm what
+    # retrieval already returned.
+    pool_size = max(args.k, args.candidates) if args.rerank else args.k
+
+    async with session_scope() as session:
+        if args.mode == "dense":
+            results = await dense_search(
+                session=session,
+                embedder=get_embedder(),
+                query=args.query,
+                k=pool_size,
+                as_of_date=args.as_of,
+                cik=args.cik,
+                form_types=form_types,
+                section_labels=section_labels,
+            )
+        elif args.mode == "bm25":
+            results = await bm25_search(
+                session=session,
+                query=args.query,
+                k=pool_size,
+                as_of_date=args.as_of,
+                cik=args.cik,
+                form_types=form_types,
+                section_labels=section_labels,
+            )
+        else:
+            results = await hybrid_search(
+                session=session,
+                embedder=get_embedder(),
+                query=args.query,
+                k=pool_size,
+                dense_candidates=args.candidates,
+                bm25_candidates=args.candidates,
+                as_of_date=args.as_of,
+                cik=args.cik,
+                form_types=form_types,
+                section_labels=section_labels,
+            )
+
+    if args.rerank:
+        results = await rerank_results(
+            reranker=get_reranker(),
+            query=args.query,
+            results=results,
+            top_k=args.k,
+        )
+
+    _print_results(results, mode=args.mode)
+    return 0
+
+
+async def _shutdown() -> None:
+    await dispose_reranker()
+    await dispose_embedder()
+    await dispose_engine()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        code = asyncio.run(_run(args))
+    finally:
+        asyncio.run(_shutdown())
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/alphamind/chunking/__init__.py
+++ b/src/alphamind/chunking/__init__.py
@@ -1,0 +1,50 @@
+"""Filing-body chunking for downstream embedding and retrieval.
+
+The public surface is:
+
+- :func:`parse_filing_html` — HTML/XBRL bytes to a flat list of text paragraphs.
+- :func:`detect_sections` — group paragraphs into 10-K/10-Q/8-K sections.
+- :func:`chunk_text` — generic paragraph-aware text splitter with overlap.
+- :func:`chunk_filing` — end-to-end: HTML in, :class:`Chunk` list out.
+
+The chunker is deliberately model-agnostic. It targets a character budget
+rather than a token budget so it does not couple to a specific tokenizer;
+the budget is configurable and sized conservatively for common embedding
+models (~1000 tokens at ~4 chars/token for English prose).
+"""
+
+from __future__ import annotations
+
+from alphamind.chunking.chunker import (
+    DEFAULT_MAX_CHARS,
+    DEFAULT_OVERLAP_CHARS,
+    Chunk,
+    chunk_filing,
+    chunk_text,
+)
+from alphamind.chunking.parser import (
+    Section,
+    detect_sections,
+    parse_filing_html,
+)
+from alphamind.chunking.service import (
+    ChunkBatchResult,
+    ChunkIngestResult,
+    chunk_bodies_for_cik,
+    chunk_filing_document,
+)
+
+__all__ = [
+    "DEFAULT_MAX_CHARS",
+    "DEFAULT_OVERLAP_CHARS",
+    "Chunk",
+    "ChunkBatchResult",
+    "ChunkIngestResult",
+    "Section",
+    "chunk_bodies_for_cik",
+    "chunk_filing",
+    "chunk_filing_document",
+    "chunk_text",
+    "detect_sections",
+    "parse_filing_html",
+]

--- a/src/alphamind/chunking/chunker.py
+++ b/src/alphamind/chunking/chunker.py
@@ -1,0 +1,234 @@
+"""Paragraph-aware text chunker with configurable overlap.
+
+The chunker packs paragraphs greedily up to a character budget, falling back
+to sentence- and then word-level splits only for paragraphs that exceed the
+budget on their own. Successive chunks share a tail of the previous chunk
+so that semantic context straddling a chunk boundary is not lost during
+retrieval.
+
+The output type :class:`Chunk` carries enough context (section label,
+section title, chunk index) for downstream code to render citations without
+re-parsing the source filing.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from alphamind.chunking.parser import detect_sections, parse_filing_html
+
+DEFAULT_MAX_CHARS = 4000
+DEFAULT_OVERLAP_CHARS = 400
+
+_PARAGRAPH_RE = re.compile(r"\n\s*\n+")
+_SENTENCE_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z(\"'\[])")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+_PARAGRAPH_SEPARATOR = "\n\n"
+
+
+@dataclass(frozen=True, slots=True)
+class Chunk:
+    """A single retrieval-ready chunk of a parsed filing.
+
+    Attributes
+    ----------
+    section_label:
+        Lowercase section identifier such as ``"item_1a"`` or ``"preamble"``.
+    section_title:
+        Section heading text if present (e.g. ``"Risk Factors"``).
+    chunk_index:
+        Zero-based position of this chunk within the filing, in reading order.
+    text:
+        Chunk body. Paragraphs are joined with ``\\n\\n``.
+    char_count:
+        ``len(text)``, materialized for convenience.
+    """
+
+    section_label: str
+    section_title: str | None
+    chunk_index: int
+    text: str
+    char_count: int
+
+
+def chunk_text(
+    text: str,
+    *,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    overlap_chars: int = DEFAULT_OVERLAP_CHARS,
+) -> list[str]:
+    """Split ``text`` into chunks of at most ``max_chars`` with overlap.
+
+    Splitting prefers paragraph boundaries, then sentence boundaries, then
+    word boundaries — in that order — so the original prose flow is
+    preserved whenever the budget allows.
+
+    Parameters
+    ----------
+    max_chars:
+        Hard upper bound on the size of any returned chunk.
+    overlap_chars:
+        Approximate length of the tail copied from one chunk into the start
+        of the next. Must be strictly less than ``max_chars``.
+    """
+
+    if max_chars <= 0:
+        raise ValueError(f"max_chars must be positive, got {max_chars}")
+    if overlap_chars < 0:
+        raise ValueError(f"overlap_chars must be non-negative, got {overlap_chars}")
+    if overlap_chars >= max_chars:
+        raise ValueError(
+            f"overlap_chars ({overlap_chars}) must be less than max_chars ({max_chars})"
+        )
+
+    units = _atomize(text, max_chars=max_chars)
+    if not units:
+        return []
+
+    chunks: list[str] = []
+    buf: list[str] = []
+    buf_len = 0
+
+    for unit in units:
+        added_len = len(unit) + (len(_PARAGRAPH_SEPARATOR) if buf else 0)
+        if buf and buf_len + added_len > max_chars:
+            chunks.append(_PARAGRAPH_SEPARATOR.join(buf))
+            buf = _tail_units(buf, overlap_chars)
+            buf_len = _joined_length(buf)
+
+        added_len = len(unit) + (len(_PARAGRAPH_SEPARATOR) if buf else 0)
+        buf.append(unit)
+        buf_len += added_len
+
+    if buf:
+        chunks.append(_PARAGRAPH_SEPARATOR.join(buf))
+
+    return chunks
+
+
+def chunk_filing(
+    html: bytes | str,
+    *,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    overlap_chars: int = DEFAULT_OVERLAP_CHARS,
+) -> list[Chunk]:
+    """Parse a filing's HTML body and return chunks ready for embedding."""
+
+    paragraphs = parse_filing_html(html)
+    sections = detect_sections(paragraphs)
+
+    out: list[Chunk] = []
+    idx = 0
+    for section in sections:
+        if not section.paragraphs:
+            continue
+        body = _PARAGRAPH_SEPARATOR.join(section.paragraphs)
+        for piece in chunk_text(body, max_chars=max_chars, overlap_chars=overlap_chars):
+            out.append(
+                Chunk(
+                    section_label=section.label,
+                    section_title=section.title,
+                    chunk_index=idx,
+                    text=piece,
+                    char_count=len(piece),
+                )
+            )
+            idx += 1
+
+    return out
+
+
+def _atomize(text: str, *, max_chars: int) -> list[str]:
+    """Break ``text`` into atomic units no larger than ``max_chars`` each.
+
+    A unit is a paragraph if it fits; otherwise it is broken into sentences;
+    if a sentence is still too big it is broken into word groups.
+    """
+
+    units: list[str] = []
+    for raw_paragraph in _PARAGRAPH_RE.split(text):
+        paragraph = _WHITESPACE_RE.sub(" ", raw_paragraph).strip()
+        if not paragraph:
+            continue
+        if len(paragraph) <= max_chars:
+            units.append(paragraph)
+            continue
+
+        for sentence in _split_sentences(paragraph):
+            if len(sentence) <= max_chars:
+                units.append(sentence)
+                continue
+            units.extend(_pack_words(sentence, max_chars=max_chars))
+
+    return units
+
+
+def _split_sentences(text: str) -> list[str]:
+    parts = [s.strip() for s in _SENTENCE_RE.split(text)]
+    return [s for s in parts if s]
+
+
+def _pack_words(text: str, *, max_chars: int) -> list[str]:
+    """Greedily group words into segments of at most ``max_chars`` chars."""
+
+    out: list[str] = []
+    current: list[str] = []
+    current_len = 0
+    for word in text.split():
+        added = len(word) + (1 if current else 0)
+        if current and current_len + added > max_chars:
+            out.append(" ".join(current))
+            current = [word]
+            current_len = len(word)
+        else:
+            current.append(word)
+            current_len += added
+    if current:
+        out.append(" ".join(current))
+    return out
+
+
+def _tail_units(units: list[str], overlap_chars: int) -> list[str]:
+    """Return a suffix of ``units`` whose joined length is ~``overlap_chars``.
+
+    The suffix is always shorter than the joined length of all ``units`` —
+    we never repeat an entire previous chunk verbatim. If no single unit
+    fits in the overlap budget, an empty list is returned and the caller
+    starts the next chunk fresh.
+    """
+
+    if overlap_chars <= 0 or not units:
+        return []
+
+    tail: list[str] = []
+    total = 0
+    for unit in reversed(units):
+        added = len(unit) + (len(_PARAGRAPH_SEPARATOR) if tail else 0)
+        if total + added > overlap_chars:
+            break
+        tail.insert(0, unit)
+        total += added
+
+    # Refuse to copy the whole previous chunk into the next one — that would
+    # be infinite-loop territory (next emit, same content, repeat).
+    if len(tail) == len(units):
+        tail = tail[1:]
+
+    return tail
+
+
+def _joined_length(units: list[str]) -> int:
+    if not units:
+        return 0
+    return sum(len(u) for u in units) + (len(units) - 1) * len(_PARAGRAPH_SEPARATOR)
+
+
+__all__ = [
+    "DEFAULT_MAX_CHARS",
+    "DEFAULT_OVERLAP_CHARS",
+    "Chunk",
+    "chunk_filing",
+    "chunk_text",
+]

--- a/src/alphamind/chunking/parser.py
+++ b/src/alphamind/chunking/parser.py
@@ -1,0 +1,223 @@
+"""Parse SEC filing HTML into structured text suitable for chunking.
+
+The parser does two jobs:
+
+1. Strip HTML/inline-XBRL down to a flat list of text paragraphs, preserving
+   reading order and collapsing whitespace.
+2. Group those paragraphs into sections keyed on the filing's own structure
+   (``Item 1A``, ``Item 7``, ``Part II``, etc.).
+
+Section detection uses a heading-pattern heuristic rather than the DOM:
+SEC filings are inconsistent about whether section titles live in ``<h*>``
+tags or are styled inline with ``<b>``/``<font>``, but the textual form
+``Item <n>`` / ``Part <roman>`` is reliable across filers and decades.
+
+Filings typically contain a table of contents that repeats every section
+heading. The deduplication pass at the end of :func:`detect_sections`
+keeps only the *longest* section per label, so the TOC entries (small)
+are discarded in favour of the body (large).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from bs4 import BeautifulSoup
+
+# A "heading-ish" block must be short. Anything longer is body text that
+# happens to start with the words "Item N" (e.g. a sentence in a paragraph).
+_MAX_HEADING_CHARS = 200
+
+# Section headings in SEC filings routinely use en-dash or em-dash to
+# separate the item label from the title (e.g. "Item 1A — Risk Factors").
+# Match both alongside ASCII hyphen and colon.
+_ITEM_RE = re.compile(
+    r"^\s*Item\s+(\d+(?:\.\d+)?[A-Za-z]?)\b\.?\s*[:\-–—]?\s*(.*)$",  # noqa: RUF001
+    re.IGNORECASE,
+)
+_PART_RE = re.compile(
+    r"^\s*Part\s+([IVX]+)\b\.?\s*[:\-–—]?\s*(.*)$",  # noqa: RUF001
+    re.IGNORECASE,
+)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+# Sentinel inserted in place of ``<br>`` before extracting text. The Private
+# Use Area codepoint is guaranteed not to appear in real filings and is not
+# whitespace, so BeautifulSoup's ``strip=True`` leaves it intact for the
+# post-extraction split.
+_BR_SENTINEL = ""
+
+# Tags whose text content forms one paragraph. ``body`` is included as a
+# fallback so unusual filings with no inner block structure still produce
+# some output. ``td``/``th`` are deliberately omitted — emitting one
+# paragraph per cell shatters tabular rows; emitting one per ``tr`` keeps
+# the row together.
+_BLOCK_TAGS = (
+    "p",
+    "div",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "li",
+    "tr",
+    "blockquote",
+    "pre",
+    "article",
+    "section",
+    "header",
+    "footer",
+    "body",
+)
+
+PREAMBLE_LABEL = "preamble"
+
+
+@dataclass(frozen=True, slots=True)
+class Section:
+    """A contiguous run of paragraphs sharing a section label.
+
+    ``label`` is a lowercase, slug-like identifier such as ``"item_1a"``,
+    ``"item_5.07"``, ``"part_ii"``, or :data:`PREAMBLE_LABEL` for content
+    that precedes the first detected heading.
+    """
+
+    label: str
+    title: str | None
+    paragraphs: list[str] = field(default_factory=list)
+
+    @property
+    def text(self) -> str:
+        """Concatenated section body with one blank line between paragraphs."""
+
+        return "\n\n".join(self.paragraphs)
+
+    @property
+    def char_count(self) -> int:
+        return sum(len(p) for p in self.paragraphs)
+
+
+def parse_filing_html(html: bytes | str) -> list[str]:
+    """Return the filing's visible text as a list of paragraphs.
+
+    Each element of the returned list is one logical paragraph: whitespace
+    is collapsed, scripts/styles are dropped, and reading order is preserved.
+
+    The parser walks leaf-most block elements (``<p>``, ``<div>``, ``<h*>``,
+    ``<li>``, ``<tr>``, ...). Inline elements (``<span>``, ``<b>``, ``<a>``,
+    inline-XBRL) are kept inline within their containing paragraph. ``<br>``
+    is promoted to a paragraph break so soft line breaks split correctly.
+    """
+
+    soup = BeautifulSoup(html, "lxml")
+
+    for tag in soup(["script", "style", "noscript", "head"]):
+        tag.decompose()
+
+    for br in soup.find_all("br"):
+        br.replace_with(_BR_SENTINEL)
+
+    paragraphs: list[str] = []
+    for elem in soup.find_all(_BLOCK_TAGS):
+        # Only leaf block elements produce paragraphs — parent blocks
+        # would otherwise double-count their children's text.
+        if elem.find(_BLOCK_TAGS):
+            continue
+        raw = elem.get_text(" ", strip=True)
+        for line in raw.split(_BR_SENTINEL):
+            cleaned = _WHITESPACE_RE.sub(" ", line).strip()
+            if cleaned:
+                paragraphs.append(cleaned)
+
+    return paragraphs
+
+
+def detect_sections(paragraphs: list[str]) -> list[Section]:
+    """Group paragraphs into sections by detecting ``Item``/``Part`` headings.
+
+    Paragraphs that precede the first detected heading land in a single
+    :data:`PREAMBLE_LABEL` section. When the same label is detected more
+    than once (typically once in the table of contents and once in the
+    body), only the longest occurrence is retained.
+    """
+
+    sections: list[Section] = []
+    current = Section(label=PREAMBLE_LABEL, title=None, paragraphs=[])
+    sections.append(current)
+
+    for paragraph in paragraphs:
+        heading = _match_heading(paragraph)
+        if heading is not None:
+            label, title = heading
+            current = Section(label=label, title=title, paragraphs=[])
+            sections.append(current)
+            continue
+        current.paragraphs.append(paragraph)
+
+    return _dedupe_sections(sections)
+
+
+def _match_heading(paragraph: str) -> tuple[str, str | None] | None:
+    """Return ``(label, title)`` if ``paragraph`` looks like a section heading."""
+
+    if len(paragraph) > _MAX_HEADING_CHARS:
+        return None
+
+    match = _ITEM_RE.match(paragraph)
+    if match is not None:
+        number = match.group(1).lower()
+        title = _clean_title(match.group(2))
+        return f"item_{number}", title
+
+    match = _PART_RE.match(paragraph)
+    if match is not None:
+        roman = match.group(1).lower()
+        title = _clean_title(match.group(2))
+        return f"part_{roman}", title
+
+    return None
+
+
+def _clean_title(raw: str) -> str | None:
+    cleaned = _WHITESPACE_RE.sub(" ", raw).strip(" .:-–—")  # noqa: RUF001
+    return cleaned or None
+
+
+def _dedupe_sections(sections: list[Section]) -> list[Section]:
+    """Keep only the longest occurrence of each label, preserving order."""
+
+    longest: dict[str, Section] = {}
+    for section in sections:
+        if section.label == PREAMBLE_LABEL and not section.paragraphs:
+            # Drop an empty preamble (filings where the very first paragraph
+            # is already a section heading).
+            continue
+        existing = longest.get(section.label)
+        if existing is None or section.char_count > existing.char_count:
+            longest[section.label] = section
+
+    # Re-order to match the first occurrence in the original list so the
+    # output reads top-to-bottom as the filing does.
+    seen: set[str] = set()
+    ordered: list[Section] = []
+    for section in sections:
+        if section.label in seen:
+            continue
+        kept = longest.get(section.label)
+        if kept is None:
+            continue
+        ordered.append(kept)
+        seen.add(section.label)
+    return ordered
+
+
+__all__ = [
+    "PREAMBLE_LABEL",
+    "Section",
+    "detect_sections",
+    "parse_filing_html",
+]

--- a/src/alphamind/chunking/service.py
+++ b/src/alphamind/chunking/service.py
@@ -1,0 +1,222 @@
+"""Persistence layer for the filing-body chunker.
+
+Reads a filing document's bytes via the configured :class:`StorageBackend`,
+runs the chunker, and writes the resulting :class:`FilingChunk` rows. The
+service is idempotent: when chunks already exist for the document under
+the same ``source_content_hash`` as the current body, the work is skipped.
+
+Two entry points:
+
+- :func:`chunk_filing_document` — single document, expects an open session.
+- :func:`chunk_bodies_for_cik` — batch over every document for a CIK,
+  opens its own session and isolates per-document failures so a single
+  bad body cannot abort the whole run.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from alphamind.chunking.chunker import (
+    DEFAULT_MAX_CHARS,
+    DEFAULT_OVERLAP_CHARS,
+    chunk_filing,
+)
+from alphamind.db.session import session_scope
+from alphamind.models.company import Company
+from alphamind.models.filing import Filing
+from alphamind.models.filing_chunk import FilingChunk
+from alphamind.models.filing_document import FilingDocument
+from alphamind.storage.base import StorageBackend
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkIngestResult:
+    """Outcome of chunking a single filing document."""
+
+    filing_document_id: int
+    chunks_written: int
+    was_skipped: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkBatchResult:
+    """Outcome of chunking every filing document for a CIK."""
+
+    cik: str
+    documents_seen: int
+    documents_chunked: int
+    documents_skipped: int
+    documents_failed: int
+    chunks_written: int
+
+
+async def chunk_filing_document(
+    *,
+    storage: StorageBackend,
+    session: AsyncSession,
+    document: FilingDocument,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    overlap_chars: int = DEFAULT_OVERLAP_CHARS,
+    force: bool = False,
+) -> ChunkIngestResult:
+    """Chunk one filing document and persist the chunks.
+
+    When ``force`` is ``False`` (the default) and existing chunks already
+    cover ``document.content_hash``, the body is not refetched and no rows
+    are written. When the parent hash has changed (or ``force=True``), any
+    stale chunks for the document are deleted and replaced with a freshly
+    computed set.
+    """
+
+    if not force:
+        existing_q = await session.execute(
+            select(func.count())
+            .select_from(FilingChunk)
+            .where(
+                FilingChunk.filing_document_id == document.id,
+                FilingChunk.source_content_hash == document.content_hash,
+            )
+        )
+        if existing_q.scalar_one() > 0:
+            return ChunkIngestResult(
+                filing_document_id=document.id,
+                chunks_written=0,
+                was_skipped=True,
+            )
+
+    body = await storage.get(document.storage_uri)
+    chunks = chunk_filing(body, max_chars=max_chars, overlap_chars=overlap_chars)
+
+    # Replace any prior chunks for this document. Cheaper and simpler than
+    # diffing chunk-by-chunk; chunk counts are at most a few hundred.
+    await session.execute(delete(FilingChunk).where(FilingChunk.filing_document_id == document.id))
+
+    if chunks:
+        rows = [
+            {
+                "filing_document_id": document.id,
+                "section_label": c.section_label,
+                "section_title": c.section_title,
+                "chunk_index": c.chunk_index,
+                "text": c.text,
+                "char_count": c.char_count,
+                "source_content_hash": document.content_hash,
+            }
+            for c in chunks
+        ]
+        await session.execute(insert(FilingChunk).values(rows))
+
+    return ChunkIngestResult(
+        filing_document_id=document.id,
+        chunks_written=len(chunks),
+        was_skipped=False,
+    )
+
+
+async def chunk_bodies_for_cik(
+    storage: StorageBackend,
+    cik: str,
+    *,
+    form_types: frozenset[str] | None = None,
+    limit: int | None = None,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    overlap_chars: int = DEFAULT_OVERLAP_CHARS,
+    force: bool = False,
+) -> ChunkBatchResult:
+    """Chunk every persisted filing document for a CIK.
+
+    Iterates over :class:`FilingDocument` rows attached to the company's
+    filings (optionally filtered by form type, optionally capped at
+    ``limit``). Each document is chunked inside its own SAVEPOINT so a
+    single failure leaves prior successes intact.
+    """
+
+    padded_cik = cik.strip().zfill(10)
+
+    async with session_scope() as session:
+        company_q = await session.execute(select(Company).where(Company.cik == padded_cik))
+        company = company_q.scalar_one_or_none()
+        if company is None:
+            raise LookupError(
+                f"company not ingested yet for cik={padded_cik!r}; run ingest_cik first"
+            )
+
+        docs_stmt = (
+            select(FilingDocument)
+            .join(Filing, Filing.id == FilingDocument.filing_id)
+            .where(Filing.company_id == company.id)
+        )
+        if form_types is not None:
+            docs_stmt = docs_stmt.where(Filing.form.in_(form_types))
+        docs_stmt = docs_stmt.order_by(Filing.filing_date.desc())
+        if limit is not None:
+            docs_stmt = docs_stmt.limit(limit)
+
+        documents = list((await session.execute(docs_stmt)).scalars())
+
+        seen = len(documents)
+        chunked = 0
+        skipped = 0
+        failed = 0
+        total_chunks = 0
+
+        for document in documents:
+            try:
+                async with session.begin_nested():
+                    result = await chunk_filing_document(
+                        storage=storage,
+                        session=session,
+                        document=document,
+                        max_chars=max_chars,
+                        overlap_chars=overlap_chars,
+                        force=force,
+                    )
+            except Exception:
+                logger.exception(
+                    "chunking failed cik=%s filing_document_id=%s",
+                    padded_cik,
+                    document.id,
+                )
+                failed += 1
+                continue
+
+            if result.was_skipped:
+                skipped += 1
+            else:
+                chunked += 1
+                total_chunks += result.chunks_written
+
+    logger.info(
+        "chunking cik=%s seen=%d chunked=%d skipped=%d failed=%d chunks=%d",
+        padded_cik,
+        seen,
+        chunked,
+        skipped,
+        failed,
+        total_chunks,
+    )
+
+    return ChunkBatchResult(
+        cik=padded_cik,
+        documents_seen=seen,
+        documents_chunked=chunked,
+        documents_skipped=skipped,
+        documents_failed=failed,
+        chunks_written=total_chunks,
+    )
+
+
+__all__ = [
+    "ChunkBatchResult",
+    "ChunkIngestResult",
+    "chunk_bodies_for_cik",
+    "chunk_filing_document",
+]

--- a/src/alphamind/config.py
+++ b/src/alphamind/config.py
@@ -17,6 +17,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 Environment = Literal["development", "test", "staging", "production"]
 StorageBackend = Literal["local"]
+EmbedderBackend = Literal["deterministic", "gemini"]
+RerankerBackend = Literal["deterministic", "cross_encoder"]
 
 
 class Settings(BaseSettings):
@@ -65,6 +67,52 @@ class Settings(BaseSettings):
         ),
     )
 
+    # --- Embedding backend ---
+    embedder_backend: EmbedderBackend = Field(
+        default="deterministic",
+        description=(
+            "Backend used by alphamind.embeddings. 'deterministic' is hash-"
+            "based and model-free (useful for tests and dev); 'gemini' calls "
+            "Google's text-embedding-004 endpoint and requires GOOGLE_API_KEY."
+        ),
+    )
+    embedder_dimension: int = Field(
+        default=768,
+        description=(
+            "Vector dimension for the embedder. Must match the `vector(N)` "
+            "column type declared in the filing_chunks migration. 768 matches "
+            "Gemini's text-embedding-004 output."
+        ),
+    )
+    google_api_key: str | None = Field(
+        default=None,
+        description=(
+            "API key for Google's generative-language endpoints. Required "
+            "when embedder_backend='gemini'."
+        ),
+    )
+    gemini_embedding_model: str = Field(
+        default="text-embedding-004",
+        description="Gemini embedding model identifier (path segment in the REST URL).",
+    )
+
+    # --- Reranker backend ---
+    reranker_backend: RerankerBackend = Field(
+        default="deterministic",
+        description=(
+            "Backend used by alphamind.reranking. 'deterministic' is a Jaccard-"
+            "overlap reranker with no dependencies; 'cross_encoder' uses "
+            "sentence-transformers and requires the 'rerank' optional extra."
+        ),
+    )
+    cross_encoder_model: str = Field(
+        default="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        description=(
+            "Hugging Face model id for the cross-encoder reranker. The default "
+            "is small (~90MB) and fast on CPU."
+        ),
+    )
+
     @property
     def is_production(self) -> bool:
         return self.environment == "production"
@@ -77,4 +125,11 @@ def get_settings() -> Settings:
     return Settings()  # type: ignore[call-arg]
 
 
-__all__ = ["Environment", "Settings", "StorageBackend", "get_settings"]
+__all__ = [
+    "EmbedderBackend",
+    "Environment",
+    "RerankerBackend",
+    "Settings",
+    "StorageBackend",
+    "get_settings",
+]

--- a/src/alphamind/db/migrations/env.py
+++ b/src/alphamind/db/migrations/env.py
@@ -30,6 +30,23 @@ config.set_main_option("sqlalchemy.url", get_settings().database_url)
 target_metadata = Base.metadata
 
 
+_RAW_SQL_INDEX_NAMES = frozenset({"ix_filing_chunks_text_tsv", "ix_filing_chunks_embedding_hnsw"})
+
+
+def _include_object(obj, name, type_, reflected, compare_to) -> bool:  # type: ignore[no-untyped-def]
+    """Skip autogenerate diffs for objects that live only in raw-SQL migrations.
+
+    The tsvector generated column and the HNSW/GIN indexes on ``filing_chunks``
+    are managed by migration 0007. Declaring them in SQLAlchemy core is awkward
+    (HNSW is not a first-class index type), so we exclude them from autogenerate
+    comparison rather than fight the ORM.
+    """
+
+    if type_ == "column" and name == "text_tsv":
+        return False
+    return not (type_ == "index" and name in _RAW_SQL_INDEX_NAMES)
+
+
 def run_migrations_offline() -> None:
     """Run migrations without a live DB connection (emits SQL to stdout)."""
 
@@ -41,6 +58,7 @@ def run_migrations_offline() -> None:
         dialect_opts={"paramstyle": "named"},
         compare_type=True,
         compare_server_default=True,
+        include_object=_include_object,
     )
 
     with context.begin_transaction():
@@ -53,6 +71,7 @@ def do_run_migrations(connection: Connection) -> None:
         target_metadata=target_metadata,
         compare_type=True,
         compare_server_default=True,
+        include_object=_include_object,
     )
 
     with context.begin_transaction():

--- a/src/alphamind/db/migrations/versions/20260510_1200_0004_filing_chunks.py
+++ b/src/alphamind/db/migrations/versions/20260510_1200_0004_filing_chunks.py
@@ -1,0 +1,86 @@
+"""create filing_chunks table
+
+Revision ID: 0004_filing_chunks
+Revises: 0003_filing_documents
+Create Date: 2026-05-10 12:00:00+00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0004_filing_chunks"
+down_revision: str | Sequence[str] | None = "0003_filing_documents"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "filing_chunks",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("filing_document_id", sa.Integer(), nullable=False),
+        sa.Column("section_label", sa.String(length=64), nullable=False),
+        sa.Column("section_title", sa.String(length=256), nullable=True),
+        sa.Column("chunk_index", sa.Integer(), nullable=False),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("char_count", sa.Integer(), nullable=False),
+        sa.Column("source_content_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["filing_document_id"],
+            ["filing_documents.id"],
+            name=op.f("fk_filing_chunks_filing_document_id_filing_documents"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_filing_chunks")),
+        sa.UniqueConstraint(
+            "filing_document_id",
+            "chunk_index",
+            name=op.f("uq_filing_chunks_filing_document_id"),
+        ),
+    )
+    op.create_index(
+        op.f("ix_filing_chunks_filing_document_id"),
+        "filing_chunks",
+        ["filing_document_id"],
+    )
+    op.create_index(
+        op.f("ix_filing_chunks_section_label"),
+        "filing_chunks",
+        ["section_label"],
+    )
+    op.create_index(
+        op.f("ix_filing_chunks_source_content_hash"),
+        "filing_chunks",
+        ["source_content_hash"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_filing_chunks_source_content_hash"),
+        table_name="filing_chunks",
+    )
+    op.drop_index(op.f("ix_filing_chunks_section_label"), table_name="filing_chunks")
+    op.drop_index(
+        op.f("ix_filing_chunks_filing_document_id"),
+        table_name="filing_chunks",
+    )
+    op.drop_table("filing_chunks")

--- a/src/alphamind/db/migrations/versions/20260510_1400_0005_chunk_embeddings.py
+++ b/src/alphamind/db/migrations/versions/20260510_1400_0005_chunk_embeddings.py
@@ -1,0 +1,57 @@
+"""add embedding columns to filing_chunks
+
+Revision ID: 0005_chunk_embeddings
+Revises: 0004_filing_chunks
+Create Date: 2026-05-10 14:00:00+00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from pgvector.sqlalchemy import Vector
+
+# revision identifiers, used by Alembic.
+revision: str = "0005_chunk_embeddings"
+down_revision: str | Sequence[str] | None = "0004_filing_chunks"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Must match ``EMBEDDING_DIMENSION`` in alphamind.models.filing_chunk and
+# ``embedder_dimension`` in alphamind.config. Changing this requires a
+# follow-up migration that ALTERs the column type.
+EMBEDDING_DIMENSION = 384
+
+
+def upgrade() -> None:
+    op.add_column(
+        "filing_chunks",
+        sa.Column("embedding", Vector(EMBEDDING_DIMENSION), nullable=True),
+    )
+    op.add_column(
+        "filing_chunks",
+        sa.Column("embedding_model", sa.String(length=128), nullable=True),
+    )
+    op.add_column(
+        "filing_chunks",
+        sa.Column("embedded_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Partial index on (embedding_model) over rows that have been embedded.
+    # Lets the embedding service cheaply find the "needs (re-)embedding" set
+    # for a given model name without scanning the whole table.
+    op.create_index(
+        op.f("ix_filing_chunks_embedding_model"),
+        "filing_chunks",
+        ["embedding_model"],
+        postgresql_where=sa.text("embedding_model IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_filing_chunks_embedding_model"), table_name="filing_chunks")
+    op.drop_column("filing_chunks", "embedded_at")
+    op.drop_column("filing_chunks", "embedding_model")
+    op.drop_column("filing_chunks", "embedding")

--- a/src/alphamind/db/migrations/versions/20260510_1600_0006_widen_embedding_to_768.py
+++ b/src/alphamind/db/migrations/versions/20260510_1600_0006_widen_embedding_to_768.py
@@ -1,0 +1,50 @@
+"""widen filing_chunks.embedding from vector(384) to vector(768)
+
+Revision ID: 0006_widen_embedding_to_768
+Revises: 0005_chunk_embeddings
+Create Date: 2026-05-10 16:00:00+00:00
+
+Picked to match Gemini's ``text-embedding-004`` output (768 dim). The
+column type is replaced (drop + add) rather than ALTERed; vectors stored
+under the old dimension are unrecoverable at the new size and the table
+is small in early development.
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from pgvector.sqlalchemy import Vector
+
+# revision identifiers, used by Alembic.
+revision: str = "0006_widen_embedding_to_768"
+down_revision: str | Sequence[str] | None = "0005_chunk_embeddings"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+NEW_DIMENSION = 768
+OLD_DIMENSION = 384
+
+
+def upgrade() -> None:
+    # NULL out the column before swapping types; pgvector cannot coerce a
+    # 384-vector into a 768-vector. ``embedding_model`` is cleared too so
+    # the embedding service re-encodes any orphaned rows.
+    op.execute("UPDATE filing_chunks SET embedding = NULL, embedding_model = NULL")
+    op.drop_column("filing_chunks", "embedding")
+    op.add_column(
+        "filing_chunks",
+        sa.Column("embedding", Vector(NEW_DIMENSION), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.execute("UPDATE filing_chunks SET embedding = NULL, embedding_model = NULL")
+    op.drop_column("filing_chunks", "embedding")
+    op.add_column(
+        "filing_chunks",
+        sa.Column("embedding", Vector(OLD_DIMENSION), nullable=True),
+    )

--- a/src/alphamind/db/migrations/versions/20260510_1800_0007_retrieval_indexes.py
+++ b/src/alphamind/db/migrations/versions/20260510_1800_0007_retrieval_indexes.py
@@ -1,0 +1,52 @@
+"""add retrieval indexes for hybrid search
+
+Revision ID: 0007_retrieval_indexes
+Revises: 0006_widen_embedding_to_768
+Create Date: 2026-05-10 18:00:00+00:00
+
+Two physical indexes back :mod:`alphamind.retrieval`:
+
+* a generated ``tsvector`` column with a GIN index for BM25-style keyword
+  search via ``ts_rank_cd``;
+* an HNSW index on ``embedding`` using ``vector_cosine_ops`` for the dense
+  side of the hybrid search.
+
+The ``english`` tsvector configuration is a reasonable default for SEC
+filings; switching to a custom config later is a follow-up migration.
+HNSW parameters are left at pgvector defaults (m=16, ef_construction=64)
+which work well for corpora up to a few million vectors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0007_retrieval_indexes"
+down_revision: str | Sequence[str] | None = "0006_widen_embedding_to_768"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Generated tsvector column. STORED so reads do not recompute.
+    op.execute(
+        "ALTER TABLE filing_chunks "
+        "ADD COLUMN text_tsv tsvector "
+        "GENERATED ALWAYS AS (to_tsvector('english', text)) STORED"
+    )
+    op.execute("CREATE INDEX ix_filing_chunks_text_tsv ON filing_chunks USING GIN (text_tsv)")
+
+    # HNSW on the embedding column for cosine-distance ANN.
+    op.execute(
+        "CREATE INDEX ix_filing_chunks_embedding_hnsw "
+        "ON filing_chunks USING hnsw (embedding vector_cosine_ops)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_filing_chunks_embedding_hnsw")
+    op.execute("DROP INDEX IF EXISTS ix_filing_chunks_text_tsv")
+    op.execute("ALTER TABLE filing_chunks DROP COLUMN IF EXISTS text_tsv")

--- a/src/alphamind/embeddings/__init__.py
+++ b/src/alphamind/embeddings/__init__.py
@@ -1,0 +1,41 @@
+"""Text-to-vector encoding for filing chunks.
+
+Public surface:
+
+- :class:`Embedder` — backend protocol.
+- :class:`DeterministicEmbedder` — hash-based, model-free, deterministic.
+- :func:`get_embedder` — config-driven singleton accessor.
+"""
+
+from __future__ import annotations
+
+from alphamind.embeddings.base import Embedder, EmbedderError, Vector
+from alphamind.embeddings.deterministic import (
+    DEFAULT_DIMENSION,
+    DeterministicEmbedder,
+)
+from alphamind.embeddings.factory import dispose_embedder, get_embedder
+from alphamind.embeddings.gemini import GeminiEmbedder
+from alphamind.embeddings.service import (
+    DEFAULT_BATCH_SIZE,
+    EmbedBatchResult,
+    EmbedIngestResult,
+    embed_chunks_for_cik,
+    embed_chunks_for_document,
+)
+
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "DEFAULT_DIMENSION",
+    "DeterministicEmbedder",
+    "EmbedBatchResult",
+    "EmbedIngestResult",
+    "Embedder",
+    "EmbedderError",
+    "GeminiEmbedder",
+    "Vector",
+    "dispose_embedder",
+    "embed_chunks_for_cik",
+    "embed_chunks_for_document",
+    "get_embedder",
+]

--- a/src/alphamind/embeddings/base.py
+++ b/src/alphamind/embeddings/base.py
@@ -1,0 +1,53 @@
+"""Embedder protocol shared by every concrete implementation.
+
+Backends differ along three dimensions: vector dimension, model identity
+(used for staleness checks), and physical implementation (local model,
+hosted API, ...). The protocol fixes the interface so call sites — the
+embedding service and any future retrieval code — can swap backends via
+:mod:`alphamind.embeddings.factory` without touching their own code.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+Vector = list[float]
+
+
+class EmbedderError(RuntimeError):
+    """Raised when an embedder cannot satisfy a request."""
+
+
+@runtime_checkable
+class Embedder(Protocol):
+    """A batch text-to-vector encoder.
+
+    Implementations must be safe to call concurrently from multiple asyncio
+    tasks. The vectors returned for two equal input strings must compare
+    equal — embedding determinism lets the service skip work and lets tests
+    assert against expected values.
+    """
+
+    @property
+    def model_name(self) -> str:
+        """Stable identifier for this embedder, e.g. ``"fake-hash-384"``.
+
+        Persisted alongside each embedding so the service can detect when
+        the configured backend has changed and trigger a re-embed.
+        """
+        ...
+
+    @property
+    def dimension(self) -> int:
+        """Number of components in each returned :data:`Vector`."""
+        ...
+
+    async def embed(self, texts: list[str]) -> list[Vector]:
+        """Encode ``texts`` into vectors. Order is preserved.
+
+        Raises :class:`EmbedderError` if the backend cannot encode a batch.
+        """
+        ...
+
+
+__all__ = ["Embedder", "EmbedderError", "Vector"]

--- a/src/alphamind/embeddings/deterministic.py
+++ b/src/alphamind/embeddings/deterministic.py
@@ -1,0 +1,79 @@
+"""Deterministic hash-based embedder for tests and local development.
+
+This is a *real* embedder in the sense that it implements the protocol and
+produces stable, L2-normalised vectors. It is *not* a semantically useful
+embedder — there is no model and no training signal. Use it to exercise
+the embedding/retrieval plumbing while a real backend is wired up.
+
+The vector for a given text is built bag-of-words style: each whitespace-
+separated token is mapped to a fixed index via a SHA-256 hash and adds a
+sign-flipped unit to the corresponding coordinate. The sum is then
+L2-normalised so cosine similarity is well defined. Two texts that share
+many tokens get visibly similar vectors; unrelated texts get nearly
+orthogonal vectors — enough structure to test retrieval mechanics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import math
+import re
+
+from alphamind.embeddings.base import Vector
+
+DEFAULT_DIMENSION = 768
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+class DeterministicEmbedder:
+    """Hash-based embedder that produces stable vectors without a model.
+
+    Parameters
+    ----------
+    dimension:
+        Length of each returned vector. Defaults to 384 to match
+        ``sentence-transformers/all-MiniLM-L6-v2``, the most likely first
+        real backend.
+    """
+
+    def __init__(self, *, dimension: int = DEFAULT_DIMENSION) -> None:
+        if dimension <= 0:
+            raise ValueError(f"dimension must be positive, got {dimension}")
+        self._dimension = dimension
+        self._model_name = f"deterministic-hash-{dimension}"
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    async def embed(self, texts: list[str]) -> list[Vector]:
+        # Pure CPU work; hop to a worker thread so we don't block the event
+        # loop on a large batch.
+        return await asyncio.to_thread(self._embed_sync, texts)
+
+    def _embed_sync(self, texts: list[str]) -> list[Vector]:
+        return [self._encode(text) for text in texts]
+
+    def _encode(self, text: str) -> Vector:
+        vector = [0.0] * self._dimension
+        for token in _TOKEN_RE.findall(text.lower()):
+            digest = hashlib.sha256(token.encode("utf-8")).digest()
+            index = int.from_bytes(digest[:4], "big") % self._dimension
+            # Use the next byte to flip sign so colliding tokens don't always
+            # reinforce; weak but cheap signal differentiation.
+            sign = 1.0 if digest[4] & 1 else -1.0
+            vector[index] += sign
+
+        norm = math.sqrt(sum(v * v for v in vector))
+        if norm == 0.0:
+            return vector
+        return [v / norm for v in vector]
+
+
+__all__ = ["DEFAULT_DIMENSION", "DeterministicEmbedder"]

--- a/src/alphamind/embeddings/factory.py
+++ b/src/alphamind/embeddings/factory.py
@@ -1,0 +1,51 @@
+"""Factory that returns the configured embedder as a process-wide singleton."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from alphamind.config import get_settings
+from alphamind.embeddings.base import Embedder, EmbedderError
+from alphamind.embeddings.deterministic import DeterministicEmbedder
+from alphamind.embeddings.gemini import GeminiEmbedder
+
+
+@lru_cache(maxsize=1)
+def get_embedder() -> Embedder:
+    """Return the process-wide embedder instance."""
+
+    settings = get_settings()
+    backend = settings.embedder_backend.lower()
+
+    if backend == "deterministic":
+        return DeterministicEmbedder(dimension=settings.embedder_dimension)
+
+    if backend == "gemini":
+        if not settings.google_api_key:
+            raise EmbedderError("embedder_backend='gemini' requires GOOGLE_API_KEY to be set")
+        return GeminiEmbedder(
+            api_key=settings.google_api_key,
+            model=settings.gemini_embedding_model,
+            dimension=settings.embedder_dimension,
+        )
+
+    raise EmbedderError(f"unsupported embedder backend: {backend!r}")
+
+
+async def dispose_embedder() -> None:
+    """Close the cached embedder's HTTP client and clear the cache.
+
+    Mirrors :func:`alphamind.db.session.dispose_engine`. Safe to call when
+    no embedder has been constructed yet.
+    """
+
+    if get_embedder.cache_info().currsize == 0:
+        return
+    embedder = get_embedder()
+    aclose = getattr(embedder, "aclose", None)
+    if aclose is not None:
+        await aclose()
+    get_embedder.cache_clear()
+
+
+__all__ = ["dispose_embedder", "get_embedder"]

--- a/src/alphamind/embeddings/gemini.py
+++ b/src/alphamind/embeddings/gemini.py
@@ -1,0 +1,211 @@
+"""Embedder backed by Google's ``generativelanguage`` REST endpoint.
+
+This implementation talks directly to the REST API rather than pulling in
+``google-genai`` — the project already standardises on httpx + tenacity +
+respx for outbound HTTP (see :class:`alphamind.ingestion.edgar.client`)
+and that stack covers everything we need (retries, rate limiting, mocked
+tests) without another SDK on the dep tree.
+
+Auth uses the API key as a query parameter, which is what the free-tier
+``generativelanguage.googleapis.com`` endpoints accept.
+
+Batching is done via ``:batchEmbedContents`` — up to 100 inputs per call
+on the free tier — and the embedder slices oversized inputs into chunks
+of :data:`MAX_BATCH_SIZE` transparently so callers do not need to know
+the limit.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import TracebackType
+from typing import Any, Self
+
+import httpx
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from alphamind.embeddings.base import EmbedderError, Vector
+from alphamind.ingestion.edgar.client import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta"
+
+# Free-tier ``text-embedding-004`` limit: 1500 RPM. The default below
+# stays comfortably under it; callers can raise it for paid tiers.
+DEFAULT_RATE_PER_SECOND = 20
+DEFAULT_TIMEOUT_SECONDS = 30.0
+DEFAULT_MAX_RETRIES = 5
+
+# ``batchEmbedContents`` accepts up to 100 inputs per call.
+MAX_BATCH_SIZE = 100
+
+_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+
+class _RetryableStatusError(httpx.HTTPStatusError):
+    """Marker subclass used by tenacity to trigger a retry."""
+
+
+class GeminiEmbedder:
+    """Async embedder calling Google's ``text-embedding-004`` REST endpoint.
+
+    Construct from :func:`alphamind.embeddings.factory.get_embedder` in
+    normal use; the direct constructor is exposed for tests that need to
+    inject a custom :class:`httpx.AsyncBaseTransport` for respx mocking.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = "text-embedding-004",
+        dimension: int = 768,
+        rate: int = DEFAULT_RATE_PER_SECOND,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key must be non-empty")
+        if dimension <= 0:
+            raise ValueError(f"dimension must be positive, got {dimension}")
+
+        self._api_key = api_key
+        self._model = model
+        self._dimension = dimension
+        self._model_name = f"gemini:{model}"
+        self._client = httpx.AsyncClient(
+            timeout=timeout,
+            headers={"Content-Type": "application/json"},
+            transport=transport,
+        )
+        self._limiter = TokenBucketLimiter(rate=rate)
+        self._max_retries = max_retries
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def embed(self, texts: list[str]) -> list[Vector]:
+        if not texts:
+            return []
+
+        # Slice oversized inputs into batches of MAX_BATCH_SIZE and issue
+        # them sequentially. Concurrent batches would risk the per-minute
+        # quota; sequential keeps rate-limit accounting simple.
+        results: list[Vector] = []
+        for start in range(0, len(texts), MAX_BATCH_SIZE):
+            batch = texts[start : start + MAX_BATCH_SIZE]
+            results.extend(await self._embed_batch(batch))
+        return results
+
+    async def _embed_batch(self, texts: list[str]) -> list[Vector]:
+        url = f"{GEMINI_API_BASE}/models/{self._model}:batchEmbedContents"
+        payload = {
+            "requests": [
+                {
+                    "model": f"models/{self._model}",
+                    "content": {"parts": [{"text": text}]},
+                }
+                for text in texts
+            ]
+        }
+
+        retryer = retry(
+            stop=stop_after_attempt(self._max_retries),
+            wait=wait_exponential(multiplier=1, min=1, max=30),
+            retry=retry_if_exception_type((httpx.TransportError, _RetryableStatusError)),
+            reraise=True,
+        )
+
+        @retryer
+        async def _do() -> httpx.Response:
+            await self._limiter.acquire()
+            response = await self._client.post(
+                url,
+                params={"key": self._api_key},
+                json=payload,
+            )
+            if response.status_code in _RETRYABLE_STATUS:
+                raise _RetryableStatusError(
+                    f"retryable status {response.status_code}",
+                    request=response.request,
+                    response=response,
+                )
+            response.raise_for_status()
+            return response
+
+        try:
+            response = await _do()
+        except httpx.HTTPStatusError as exc:
+            # 4xx other than 429: not retryable, surface as embedder error.
+            raise EmbedderError(
+                f"gemini embed failed ({exc.response.status_code}): {exc.response.text[:200]}"
+            ) from exc
+        except httpx.TransportError as exc:
+            raise EmbedderError(f"gemini embed transport error: {exc}") from exc
+
+        return _parse_batch_response(response.json(), expected=len(texts))
+
+
+def _parse_batch_response(payload: Any, *, expected: int) -> list[Vector]:
+    """Extract ``[[float, ...], ...]`` from a batchEmbedContents response.
+
+    Defensive: Google's REST layer occasionally returns extra fields or
+    omits ``values`` when the input is too long. Any deviation from the
+    expected shape becomes an :class:`EmbedderError` so the caller sees a
+    specific failure rather than a generic ``KeyError``.
+    """
+
+    if not isinstance(payload, dict):
+        raise EmbedderError(f"unexpected response payload type: {type(payload).__name__}")
+    embeddings = payload.get("embeddings")
+    if not isinstance(embeddings, list) or len(embeddings) != expected:
+        raise EmbedderError(
+            f"expected {expected} embeddings, got "
+            f"{len(embeddings) if isinstance(embeddings, list) else 'non-list'}"
+        )
+
+    out: list[Vector] = []
+    for i, entry in enumerate(embeddings):
+        if not isinstance(entry, dict):
+            raise EmbedderError(f"embedding[{i}] is not an object")
+        values = entry.get("values")
+        if not isinstance(values, list) or not all(isinstance(v, int | float) for v in values):
+            raise EmbedderError(f"embedding[{i}] has malformed 'values'")
+        out.append([float(v) for v in values])
+    return out
+
+
+__all__ = [
+    "DEFAULT_MAX_RETRIES",
+    "DEFAULT_RATE_PER_SECOND",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "GEMINI_API_BASE",
+    "MAX_BATCH_SIZE",
+    "GeminiEmbedder",
+]

--- a/src/alphamind/embeddings/service.py
+++ b/src/alphamind/embeddings/service.py
@@ -1,0 +1,218 @@
+"""Persistence layer for chunk embeddings.
+
+Reads :class:`FilingChunk` rows whose embeddings are missing or stale
+relative to the configured :class:`Embedder`, encodes them in batches,
+and writes the resulting vectors back. A chunk is considered stale when
+its ``embedding_model`` column does not match ``embedder.model_name``;
+this lets the service handle backend swaps without manual intervention.
+
+Two entry points mirror the chunking service:
+
+- :func:`embed_chunks_for_document` — one filing document, expects an
+  open session.
+- :func:`embed_chunks_for_cik` — batch over every document for a CIK,
+  opens its own session and isolates per-document failures so a single
+  bad batch cannot abort the whole run.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from alphamind.db.session import session_scope
+from alphamind.embeddings.base import Embedder
+from alphamind.models.company import Company
+from alphamind.models.filing import Filing
+from alphamind.models.filing_chunk import FilingChunk
+from alphamind.models.filing_document import FilingDocument
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 32
+
+
+@dataclass(frozen=True, slots=True)
+class EmbedIngestResult:
+    """Outcome of embedding one filing document's chunks."""
+
+    filing_document_id: int
+    chunks_embedded: int
+    chunks_skipped: int
+
+
+@dataclass(frozen=True, slots=True)
+class EmbedBatchResult:
+    """Outcome of embedding every document's chunks for a CIK."""
+
+    cik: str
+    documents_seen: int
+    documents_failed: int
+    chunks_embedded: int
+    chunks_skipped: int
+
+
+async def embed_chunks_for_document(
+    *,
+    session: AsyncSession,
+    embedder: Embedder,
+    filing_document_id: int,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    force: bool = False,
+) -> EmbedIngestResult:
+    """Embed chunks for one filing document.
+
+    Skips chunks already embedded under ``embedder.model_name`` unless
+    ``force`` is set. Vector dimension is validated against the embedder's
+    declared dimension to catch model/schema mismatches early.
+    """
+
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+
+    # Count any already-embedded chunks so the caller's skipped tally is
+    # correct even when no new work happens.
+    total_stmt = select(FilingChunk).where(FilingChunk.filing_document_id == filing_document_id)
+    all_chunks = list((await session.execute(total_stmt)).scalars())
+
+    if force:
+        to_embed = list(all_chunks)
+    else:
+        to_embed = [
+            c for c in all_chunks if c.embedding_model != embedder.model_name or c.embedding is None
+        ]
+    skipped = len(all_chunks) - len(to_embed)
+
+    if not to_embed:
+        return EmbedIngestResult(
+            filing_document_id=filing_document_id,
+            chunks_embedded=0,
+            chunks_skipped=skipped,
+        )
+
+    embedded_count = 0
+    for start in range(0, len(to_embed), batch_size):
+        batch = to_embed[start : start + batch_size]
+        vectors = await embedder.embed([c.text for c in batch])
+        if len(vectors) != len(batch):
+            raise RuntimeError(f"embedder returned {len(vectors)} vectors for {len(batch)} inputs")
+
+        now = datetime.now(UTC)
+        for chunk, vector in zip(batch, vectors, strict=True):
+            if len(vector) != embedder.dimension:
+                raise RuntimeError(
+                    f"embedder {embedder.model_name!r} returned dim={len(vector)} "
+                    f"but declared dim={embedder.dimension}"
+                )
+            chunk.embedding = vector
+            chunk.embedding_model = embedder.model_name
+            chunk.embedded_at = now
+
+        # Flush each batch so a later failure inside the SAVEPOINT only loses
+        # the in-flight batch, not earlier successes.
+        await session.flush()
+        embedded_count += len(batch)
+
+    return EmbedIngestResult(
+        filing_document_id=filing_document_id,
+        chunks_embedded=embedded_count,
+        chunks_skipped=skipped,
+    )
+
+
+async def embed_chunks_for_cik(
+    cik: str,
+    *,
+    embedder: Embedder,
+    form_types: frozenset[str] | None = None,
+    limit: int | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    force: bool = False,
+) -> EmbedBatchResult:
+    """Embed chunks for every persisted filing document of a CIK.
+
+    Iterates over documents (optionally filtered by form, optionally
+    capped at ``limit``) and embeds each inside its own SAVEPOINT so a
+    single failed batch leaves prior successes intact.
+    """
+
+    padded_cik = cik.strip().zfill(10)
+
+    async with session_scope() as session:
+        company_q = await session.execute(select(Company).where(Company.cik == padded_cik))
+        company = company_q.scalar_one_or_none()
+        if company is None:
+            raise LookupError(
+                f"company not ingested yet for cik={padded_cik!r}; run ingest_cik first"
+            )
+
+        docs_stmt = (
+            select(FilingDocument)
+            .join(Filing, Filing.id == FilingDocument.filing_id)
+            .where(Filing.company_id == company.id)
+        )
+        if form_types is not None:
+            docs_stmt = docs_stmt.where(Filing.form.in_(form_types))
+        docs_stmt = docs_stmt.order_by(Filing.filing_date.desc())
+        if limit is not None:
+            docs_stmt = docs_stmt.limit(limit)
+
+        documents = list((await session.execute(docs_stmt)).scalars())
+
+        seen = len(documents)
+        failed = 0
+        total_embedded = 0
+        total_skipped = 0
+
+        for document in documents:
+            try:
+                async with session.begin_nested():
+                    result = await embed_chunks_for_document(
+                        session=session,
+                        embedder=embedder,
+                        filing_document_id=document.id,
+                        batch_size=batch_size,
+                        force=force,
+                    )
+            except Exception:
+                logger.exception(
+                    "embedding failed cik=%s filing_document_id=%s",
+                    padded_cik,
+                    document.id,
+                )
+                failed += 1
+                continue
+
+            total_embedded += result.chunks_embedded
+            total_skipped += result.chunks_skipped
+
+    logger.info(
+        "embedding cik=%s seen=%d failed=%d embedded=%d skipped=%d model=%s",
+        padded_cik,
+        seen,
+        failed,
+        total_embedded,
+        total_skipped,
+        embedder.model_name,
+    )
+
+    return EmbedBatchResult(
+        cik=padded_cik,
+        documents_seen=seen,
+        documents_failed=failed,
+        chunks_embedded=total_embedded,
+        chunks_skipped=total_skipped,
+    )
+
+
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "EmbedBatchResult",
+    "EmbedIngestResult",
+    "embed_chunks_for_cik",
+    "embed_chunks_for_document",
+]

--- a/src/alphamind/models/__init__.py
+++ b/src/alphamind/models/__init__.py
@@ -7,6 +7,7 @@ imports this package to discover the full schema for autogenerate.
 
 from alphamind.models.company import Company
 from alphamind.models.filing import Filing
+from alphamind.models.filing_chunk import FilingChunk
 from alphamind.models.filing_document import FilingDocument
 
-__all__ = ["Company", "Filing", "FilingDocument"]
+__all__ = ["Company", "Filing", "FilingChunk", "FilingDocument"]

--- a/src/alphamind/models/filing_chunk.py
+++ b/src/alphamind/models/filing_chunk.py
@@ -1,0 +1,100 @@
+"""ORM model for a single chunk derived from a filing's primary document.
+
+A :class:`FilingChunk` row records one paragraph-aware slice of a filing
+body. Chunks are derived from the :class:`FilingDocument`'s bytes, so the
+foreign key points there rather than directly at :class:`Filing`.
+
+``source_content_hash`` stores the SHA-256 of the body the chunk was
+derived from. The chunking service compares it to the parent document's
+current ``content_hash`` to decide whether existing chunks are still valid
+or need to be regenerated — bodies on EDGAR are immutable for a given
+accession number in practice, but the column makes the staleness check
+trivial and explicit.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import Computed, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import TSVECTOR
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from alphamind.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from alphamind.models.filing_document import FilingDocument
+
+# Default embedding dimension. Must match ``embedder_dimension`` in
+# :class:`alphamind.config.Settings` and the ``vector(N)`` size set by
+# migration ``0006_widen_embedding_to_768``. Picked to match Gemini's
+# ``text-embedding-004`` output. Changing this is a migration.
+EMBEDDING_DIMENSION = 768
+
+
+class FilingChunk(Base, TimestampMixin):
+    """One retrieval-ready slice of a filing's primary document."""
+
+    __tablename__ = "filing_chunks"
+    __table_args__ = (
+        UniqueConstraint("filing_document_id", "chunk_index"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    filing_document_id: Mapped[int] = mapped_column(
+        ForeignKey("filing_documents.id", ondelete="CASCADE"),
+        index=True,
+    )
+
+    # Lowercase slug such as ``"item_1a"`` or ``"preamble"``. Indexed so the
+    # retrieval layer can filter to a specific section cheaply.
+    section_label: Mapped[str] = mapped_column(String(64), index=True)
+    section_title: Mapped[str | None] = mapped_column(String(256))
+
+    # Zero-based position of this chunk within its parent document, in
+    # reading order. Paired with ``filing_document_id`` to form the natural
+    # uniqueness constraint for upserts.
+    chunk_index: Mapped[int] = mapped_column(Integer)
+
+    text: Mapped[str] = mapped_column(Text)
+    char_count: Mapped[int] = mapped_column(Integer)
+
+    # SHA-256 of the FilingDocument body this chunk was derived from. When
+    # the parent document's content_hash diverges, the chunks are stale and
+    # the service regenerates them.
+    source_content_hash: Mapped[str] = mapped_column(String(64), index=True)
+
+    # Dense vector representation. Nullable because chunks land before they
+    # are embedded — the embedding service populates this column in a
+    # separate pass. ``embedding_model`` records which backend produced the
+    # vector so the service can detect model changes and re-embed.
+    embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(EMBEDDING_DIMENSION),
+        nullable=True,
+    )
+    embedding_model: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    embedded_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    # Generated tsvector for BM25-style retrieval. Maintained by Postgres,
+    # backed by a GIN index from migration ``0007_retrieval_indexes``. The
+    # Python type is loose because we never read the raw tsvector — only
+    # match against it in SQL via ``@@`` and rank with ``ts_rank_cd``.
+    text_tsv: Mapped[str | None] = mapped_column(
+        TSVECTOR,
+        Computed("to_tsvector('english', text)", persisted=True),
+        nullable=True,
+    )
+
+    document: Mapped[FilingDocument] = relationship(back_populates="chunks")
+
+    def __repr__(self) -> str:
+        return (
+            f"FilingChunk(document_id={self.filing_document_id}, "
+            f"section={self.section_label!r}, idx={self.chunk_index}, "
+            f"chars={self.char_count})"
+        )

--- a/src/alphamind/models/filing_document.py
+++ b/src/alphamind/models/filing_document.py
@@ -21,6 +21,7 @@ from alphamind.db.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
     from alphamind.models.filing import Filing
+    from alphamind.models.filing_chunk import FilingChunk
 
 
 class FilingDocument(Base, TimestampMixin):
@@ -57,6 +58,11 @@ class FilingDocument(Base, TimestampMixin):
     )
 
     filing: Mapped[Filing] = relationship(back_populates="document")
+    chunks: Mapped[list[FilingChunk]] = relationship(
+        back_populates="document",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
 
     def __repr__(self) -> str:
         return (

--- a/src/alphamind/reranking/__init__.py
+++ b/src/alphamind/reranking/__init__.py
@@ -1,0 +1,42 @@
+"""Cross-encoder reranking for hybrid retrieval results.
+
+Public surface:
+
+- :class:`Reranker` — backend protocol.
+- :class:`RerankedPassage` — output dataclass.
+- :class:`DeterministicReranker` — Jaccard-overlap, model-free.
+- :class:`CrossEncoderReranker` — sentence-transformers; requires the
+  ``rerank`` extra.
+- :func:`rerank_results` — adapts a reranker onto a list of
+  :class:`alphamind.retrieval.RetrievalResult`.
+- :func:`get_reranker` — config-driven singleton accessor.
+"""
+
+from __future__ import annotations
+
+from alphamind.reranking.base import (
+    RerankedPassage,
+    Reranker,
+    RerankerError,
+)
+from alphamind.reranking.cross_encoder import (
+    DEFAULT_MODEL as DEFAULT_CROSS_ENCODER_MODEL,
+)
+from alphamind.reranking.cross_encoder import (
+    CrossEncoderReranker,
+)
+from alphamind.reranking.deterministic import DeterministicReranker
+from alphamind.reranking.factory import dispose_reranker, get_reranker
+from alphamind.reranking.service import rerank_results
+
+__all__ = [
+    "DEFAULT_CROSS_ENCODER_MODEL",
+    "CrossEncoderReranker",
+    "DeterministicReranker",
+    "RerankedPassage",
+    "Reranker",
+    "RerankerError",
+    "dispose_reranker",
+    "get_reranker",
+    "rerank_results",
+]

--- a/src/alphamind/reranking/base.py
+++ b/src/alphamind/reranking/base.py
@@ -1,0 +1,58 @@
+"""Reranker protocol shared by every concrete implementation.
+
+A reranker takes a query and an ordered list of candidate passages
+(typically the top-N from :func:`alphamind.retrieval.hybrid_search`) and
+returns the same passages sorted by a fresh per-pair relevance score.
+
+The protocol mirrors :mod:`alphamind.embeddings.base`: a stable
+``model_name`` is exposed so callers can record which reranker scored a
+result, and the only required method is async-friendly so HTTP-backed
+implementations remain possible later.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+class RerankerError(RuntimeError):
+    """Raised when a reranker cannot satisfy a request."""
+
+
+@dataclass(frozen=True, slots=True)
+class RerankedPassage:
+    """A passage's reranker score, keyed back to the input chunk."""
+
+    chunk_id: int
+    score: float
+
+
+@runtime_checkable
+class Reranker(Protocol):
+    """A query+passage scorer.
+
+    Implementations must be safe to call concurrently from multiple asyncio
+    tasks. ``rerank`` must return one :class:`RerankedPassage` per input
+    pair, sorted by ``score`` descending. Ties are broken by input order
+    so the operation is deterministic when scores collide.
+    """
+
+    @property
+    def model_name(self) -> str:
+        """Stable identifier for this reranker (persisted with results)."""
+        ...
+
+    async def rerank(
+        self,
+        query: str,
+        passages: list[tuple[int, str]],
+    ) -> list[RerankedPassage]:
+        """Score every ``(chunk_id, text)`` pair against ``query``.
+
+        Raises :class:`RerankerError` if the backend cannot score a batch.
+        """
+        ...
+
+
+__all__ = ["RerankedPassage", "Reranker", "RerankerError"]

--- a/src/alphamind/reranking/cross_encoder.py
+++ b/src/alphamind/reranking/cross_encoder.py
@@ -1,0 +1,113 @@
+"""Cross-encoder reranker backed by sentence-transformers.
+
+A cross-encoder consumes a ``(query, passage)`` pair through one
+transformer forward pass and predicts a single relevance score. Unlike
+dense embeddings (which encode each text independently) the cross-encoder
+attends to the pair jointly, which is why it produces materially better
+final ordering — at the cost of being too slow to score the whole index.
+The standard recipe is what this module implements: dense + BM25 retrieve
+a candidate pool, the cross-encoder reranks it.
+
+``sentence-transformers`` is an optional dependency: install with
+``uv sync --extra rerank`` (or ``pip install 'alphamind[rerank]'``).
+Without it, this module still imports — calling :class:`CrossEncoderReranker`
+raises a clear :class:`RerankerError` so the failure mode is obvious.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from alphamind.reranking.base import RerankedPassage, RerankerError
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only typing
+    from sentence_transformers import CrossEncoder
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
+class CrossEncoderReranker:
+    """Wraps :class:`sentence_transformers.CrossEncoder` behind the protocol.
+
+    The model is loaded lazily on the first :meth:`rerank` call so import
+    of this module — and CLI startup that doesn't need the reranker —
+    stays cheap. ``model_name`` reflects the requested model identifier
+    so persisted results can be traced back to a specific checkpoint.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_name: str = DEFAULT_MODEL,
+        batch_size: int = 32,
+    ) -> None:
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        self._requested_model = model_name
+        self._batch_size = batch_size
+        self._model: CrossEncoder | None = None
+
+    @property
+    def model_name(self) -> str:
+        return f"cross-encoder:{self._requested_model}"
+
+    def _load_model(self) -> CrossEncoder:
+        if self._model is not None:
+            return self._model
+        try:
+            # Deferred import so the cross-encoder dep is truly optional;
+            # users without the 'rerank' extra installed never trigger this.
+            from sentence_transformers import CrossEncoder  # noqa: PLC0415
+        except ImportError as exc:  # pragma: no cover - exercised only when extra absent
+            raise RerankerError(
+                "CrossEncoderReranker requires the 'rerank' extra: "
+                "install with `uv sync --extra rerank`."
+            ) from exc
+
+        logger.info("loading cross-encoder model %s", self._requested_model)
+        self._model = CrossEncoder(self._requested_model)
+        return self._model
+
+    async def rerank(
+        self,
+        query: str,
+        passages: list[tuple[int, str]],
+    ) -> list[RerankedPassage]:
+        if not passages:
+            return []
+        # Model inference is CPU/GPU-bound; hop to a worker thread so the
+        # event loop is free for whatever else the caller is doing.
+        return await asyncio.to_thread(self._rerank_sync, query, passages)
+
+    def _rerank_sync(
+        self,
+        query: str,
+        passages: list[tuple[int, str]],
+    ) -> list[RerankedPassage]:
+        model = self._load_model()
+        pairs: list[list[str]] = [[query, text] for _, text in passages]
+        try:
+            raw_scores: Any = model.predict(pairs, batch_size=self._batch_size)
+        except Exception as exc:
+            raise RerankerError(f"cross-encoder inference failed: {exc}") from exc
+
+        # ``CrossEncoder.predict`` returns a numpy array of shape (N,).
+        scores = [float(s) for s in raw_scores]
+        if len(scores) != len(passages):
+            raise RerankerError(
+                f"cross-encoder returned {len(scores)} scores for {len(passages)} pairs"
+            )
+
+        scored: list[tuple[int, RerankedPassage]] = [
+            (idx, RerankedPassage(chunk_id=chunk_id, score=score))
+            for idx, ((chunk_id, _), score) in enumerate(zip(passages, scores, strict=True))
+        ]
+        scored.sort(key=lambda pair: (-pair[1].score, pair[0]))
+        return [pair[1] for pair in scored]
+
+
+__all__ = ["DEFAULT_MODEL", "CrossEncoderReranker"]

--- a/src/alphamind/reranking/deterministic.py
+++ b/src/alphamind/reranking/deterministic.py
@@ -1,0 +1,61 @@
+"""Deterministic token-overlap reranker for tests and local development.
+
+Like :class:`alphamind.embeddings.DeterministicEmbedder`, this is a real
+:class:`Reranker` that produces stable, sensible-enough scores without a
+model. The score is the Jaccard similarity of the query and passage token
+sets — texts that share more tokens with the query win. This is enough
+structure to exercise rerank plumbing while a real cross-encoder is set
+up and to keep unit tests reproducible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+from alphamind.reranking.base import RerankedPassage
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+class DeterministicReranker:
+    """Jaccard-overlap reranker. Model-free; useful for tests."""
+
+    @property
+    def model_name(self) -> str:
+        return "deterministic-jaccard"
+
+    async def rerank(
+        self,
+        query: str,
+        passages: list[tuple[int, str]],
+    ) -> list[RerankedPassage]:
+        return await asyncio.to_thread(self._rerank_sync, query, passages)
+
+    def _rerank_sync(
+        self,
+        query: str,
+        passages: list[tuple[int, str]],
+    ) -> list[RerankedPassage]:
+        query_tokens = set(_TOKEN_RE.findall(query.lower()))
+        if not query_tokens:
+            return [RerankedPassage(chunk_id=cid, score=0.0) for cid, _ in passages]
+
+        scored: list[tuple[int, RerankedPassage]] = []
+        for input_index, (chunk_id, text) in enumerate(passages):
+            passage_tokens = set(_TOKEN_RE.findall(text.lower()))
+            if not passage_tokens:
+                score = 0.0
+            else:
+                intersection = len(query_tokens & passage_tokens)
+                union = len(query_tokens | passage_tokens)
+                score = intersection / union if union else 0.0
+            scored.append((input_index, RerankedPassage(chunk_id=chunk_id, score=score)))
+
+        # Sort by score desc, then by original input order so ties are
+        # broken deterministically (matches the protocol contract).
+        scored.sort(key=lambda pair: (-pair[1].score, pair[0]))
+        return [pair[1] for pair in scored]
+
+
+__all__ = ["DeterministicReranker"]

--- a/src/alphamind/reranking/factory.py
+++ b/src/alphamind/reranking/factory.py
@@ -1,0 +1,43 @@
+"""Factory returning the configured reranker as a process-wide singleton."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from alphamind.config import get_settings
+from alphamind.reranking.base import Reranker, RerankerError
+from alphamind.reranking.cross_encoder import CrossEncoderReranker
+from alphamind.reranking.deterministic import DeterministicReranker
+
+
+@lru_cache(maxsize=1)
+def get_reranker() -> Reranker:
+    """Return the process-wide reranker instance."""
+
+    settings = get_settings()
+    backend = settings.reranker_backend.lower()
+
+    if backend == "deterministic":
+        return DeterministicReranker()
+
+    if backend == "cross_encoder":
+        return CrossEncoderReranker(model_name=settings.cross_encoder_model)
+
+    raise RerankerError(f"unsupported reranker backend: {backend!r}")
+
+
+async def dispose_reranker() -> None:
+    """Drop the cached reranker.
+
+    Mirrors :func:`alphamind.embeddings.factory.dispose_embedder`. Safe to
+    call when no reranker has been constructed yet. Concrete backends
+    have no async resources to release today; this hook exists so callers
+    can shut down uniformly across the embedding/reranking pair.
+    """
+
+    if get_reranker.cache_info().currsize == 0:
+        return
+    get_reranker.cache_clear()
+
+
+__all__ = ["dispose_reranker", "get_reranker"]

--- a/src/alphamind/reranking/service.py
+++ b/src/alphamind/reranking/service.py
@@ -1,0 +1,56 @@
+"""Glue between :class:`Reranker` and :class:`RetrievalResult`.
+
+The retrieval layer returns rich :class:`RetrievalResult` objects keyed on
+``chunk_id``. The reranker protocol speaks ``(chunk_id, text)`` tuples and
+returns ``RerankedPassage`` objects. :func:`rerank_results` is the small
+adaptor that pipes one into the other: score each result against the
+query, sort by reranker score, and return a new list with ``.score``
+replaced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from alphamind.reranking.base import Reranker
+from alphamind.retrieval.results import RetrievalResult
+
+
+async def rerank_results(
+    *,
+    reranker: Reranker,
+    query: str,
+    results: list[RetrievalResult],
+    top_k: int | None = None,
+) -> list[RetrievalResult]:
+    """Rerank ``results`` against ``query`` and optionally truncate to ``top_k``.
+
+    ``score`` on the returned :class:`RetrievalResult` is overwritten with
+    the reranker's score; the per-retriever ranks (``dense_rank``,
+    ``bm25_rank``) are preserved so callers can still see which retriever
+    surfaced each chunk in the candidate pool.
+    """
+
+    if not results:
+        return []
+    if top_k is not None and top_k <= 0:
+        raise ValueError(f"top_k must be positive when set, got {top_k}")
+
+    passages = [(r.chunk_id, r.text) for r in results]
+    reranked = await reranker.rerank(query, passages)
+
+    by_id = {r.chunk_id: r for r in results}
+    out: list[RetrievalResult] = []
+    for entry in reranked:
+        base = by_id.get(entry.chunk_id)
+        if base is None:
+            # Shouldn't happen — the reranker returns the same chunk_ids
+            # it was given — but skipping is safer than crashing in prod.
+            continue
+        out.append(replace(base, score=entry.score))
+    if top_k is not None:
+        out = out[:top_k]
+    return out
+
+
+__all__ = ["rerank_results"]

--- a/src/alphamind/retrieval/__init__.py
+++ b/src/alphamind/retrieval/__init__.py
@@ -1,0 +1,41 @@
+"""Hybrid retrieval over filing chunks.
+
+Public surface:
+
+- :class:`RetrievalResult` — one ranked chunk with enough context to cite.
+- :func:`reciprocal_rank_fusion` — pure function that fuses ranked lists.
+- :func:`dense_search` — pgvector cosine ANN over ``filing_chunks.embedding``.
+- :func:`bm25_search` — ``ts_rank_cd`` BM25-style search over the generated
+  ``text_tsv`` column.
+- :func:`hybrid_search` — runs both searches and fuses the results via RRF.
+
+All three search functions accept optional filters: ``as_of_date`` (no
+filings dated after it — required for honest backtests), ``cik``,
+``form_types``, and ``section_labels``.
+"""
+
+from __future__ import annotations
+
+from alphamind.retrieval.fusion import (
+    DEFAULT_RRF_K,
+    reciprocal_rank_fusion,
+)
+from alphamind.retrieval.results import RetrievalResult
+from alphamind.retrieval.service import (
+    DEFAULT_CANDIDATES,
+    DEFAULT_TOP_K,
+    bm25_search,
+    dense_search,
+    hybrid_search,
+)
+
+__all__ = [
+    "DEFAULT_CANDIDATES",
+    "DEFAULT_RRF_K",
+    "DEFAULT_TOP_K",
+    "RetrievalResult",
+    "bm25_search",
+    "dense_search",
+    "hybrid_search",
+    "reciprocal_rank_fusion",
+]

--- a/src/alphamind/retrieval/fusion.py
+++ b/src/alphamind/retrieval/fusion.py
@@ -1,0 +1,70 @@
+"""Reciprocal Rank Fusion (RRF) — score-free fusion of ranked lists.
+
+RRF is the standard way to combine results from heterogeneous retrievers
+where the raw scores are not directly comparable (BM25 and cosine
+similarity, in our case). The fused score for a document ``d`` is:
+
+    RRF(d) = sum over rankings r: 1 / (k + rank_r(d))
+
+where ``rank_r(d)`` is the 1-indexed position of ``d`` in ranking ``r``.
+Documents absent from a ranking contribute 0. ``k=60`` is the value from
+Cormack et al. (2009) and is a reasonable default — the larger ``k`` is,
+the less the top of a ranking dominates the fused order.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TypeVar
+
+# Cormack et al. (2009) constant. Independent of the underlying retrievers;
+# tune only if a downstream evaluation suite says you should.
+DEFAULT_RRF_K = 60
+
+T = TypeVar("T")
+
+
+def reciprocal_rank_fusion(
+    rankings: Sequence[Sequence[T]],
+    *,
+    k: int = DEFAULT_RRF_K,
+) -> list[tuple[T, float]]:
+    """Fuse ``rankings`` into a single ordered list under RRF scoring.
+
+    Parameters
+    ----------
+    rankings:
+        Each inner sequence is a ranking — most relevant item first. Items
+        may be of any hashable type (typically chunk IDs).
+    k:
+        Smoothing constant. Must be non-negative. Larger values flatten the
+        contribution of early ranks.
+
+    Returns
+    -------
+    A list of ``(item, fused_score)`` pairs sorted by score descending. Ties
+    are broken by the item's first appearance order across the input
+    rankings, which is deterministic.
+    """
+
+    if k < 0:
+        raise ValueError(f"k must be non-negative, got {k}")
+
+    scores: dict[T, float] = {}
+    first_seen: dict[T, int] = {}
+    counter = 0
+
+    for ranking in rankings:
+        for rank, item in enumerate(ranking, start=1):
+            scores[item] = scores.get(item, 0.0) + 1.0 / (k + rank)
+            if item not in first_seen:
+                first_seen[item] = counter
+                counter += 1
+
+    return sorted(
+        scores.items(),
+        key=lambda kv: (-kv[1], first_seen[kv[0]]),
+    )
+
+
+__all__ = ["DEFAULT_RRF_K", "reciprocal_rank_fusion"]

--- a/src/alphamind/retrieval/results.py
+++ b/src/alphamind/retrieval/results.py
@@ -1,0 +1,48 @@
+"""Retrieval result dataclass shared by every search function.
+
+A :class:`RetrievalResult` carries enough context to cite the chunk back
+to a source filing without a second round-trip to the database. The
+``score`` is whatever the producer is ranking by — cosine similarity for
+:func:`dense_search`, ``ts_rank_cd`` for :func:`bm25_search`, the fused
+RRF score for :func:`hybrid_search`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalResult:
+    """One ranked chunk plus the filing context needed to cite it."""
+
+    chunk_id: int
+    filing_document_id: int
+    filing_id: int
+
+    cik: str
+    ticker: str | None
+    company_name: str
+    form: str
+    filing_date: date
+    accession_number: str
+
+    section_label: str
+    section_title: str | None
+    chunk_index: int
+    text: str
+
+    # Ranking signal. Interpretation depends on the producer; see module
+    # docstring on each search function for specifics.
+    score: float
+
+    # Per-retriever ranks (1-indexed) carried through hybrid_search for
+    # debuggability. ``None`` when the chunk did not appear in that
+    # retriever's top-K. Always ``None`` for the single-retriever
+    # functions.
+    dense_rank: int | None = None
+    bm25_rank: int | None = None
+
+
+__all__ = ["RetrievalResult"]

--- a/src/alphamind/retrieval/service.py
+++ b/src/alphamind/retrieval/service.py
@@ -1,0 +1,288 @@
+"""Hybrid retrieval over ``filing_chunks``.
+
+The retrieval layer exposes three search functions:
+
+- :func:`dense_search` ranks chunks by cosine similarity of their stored
+  ``embedding`` against the query's embedding. Backed by the HNSW index
+  from migration ``0007_retrieval_indexes``.
+- :func:`bm25_search` ranks chunks by ``ts_rank_cd`` over the generated
+  ``text_tsv`` column. Backed by the GIN index from the same migration.
+- :func:`hybrid_search` runs both searches and fuses the rankings via
+  Reciprocal Rank Fusion.
+
+All three accept the same set of optional filters: ``as_of_date`` (no
+filings dated after it — critical for honest backtests), ``cik``,
+``form_types``, and ``section_labels``.
+
+The functions take an :class:`AsyncSession`; pass one from
+:func:`alphamind.db.session.session_scope` at call sites that own a unit
+of work, or hand-craft a session in a request handler.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from datetime import date
+from typing import Any
+
+from sqlalchemy import ColumnElement, Select, desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from alphamind.embeddings.base import Embedder
+from alphamind.models.company import Company
+from alphamind.models.filing import Filing
+from alphamind.models.filing_chunk import FilingChunk
+from alphamind.models.filing_document import FilingDocument
+from alphamind.retrieval.fusion import DEFAULT_RRF_K, reciprocal_rank_fusion
+from alphamind.retrieval.results import RetrievalResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TOP_K = 20
+DEFAULT_CANDIDATES = 100
+TSV_CONFIG = "english"
+
+
+def _base_select(score_expr: ColumnElement[Any]) -> Select[Any]:
+    """Return a SELECT joining chunk → document → filing → company.
+
+    The score expression is appended as the last column so result hydration
+    can pull it positionally from each row.
+    """
+
+    return (
+        select(
+            FilingChunk.id,
+            FilingChunk.filing_document_id,
+            FilingChunk.section_label,
+            FilingChunk.section_title,
+            FilingChunk.chunk_index,
+            FilingChunk.text,
+            FilingDocument.filing_id,
+            Filing.form,
+            Filing.filing_date,
+            Filing.accession_number,
+            Company.cik,
+            Company.ticker,
+            Company.name,
+            score_expr.label("score"),
+        )
+        .join(FilingDocument, FilingDocument.id == FilingChunk.filing_document_id)
+        .join(Filing, Filing.id == FilingDocument.filing_id)
+        .join(Company, Company.id == Filing.company_id)
+    )
+
+
+def _apply_filters(
+    stmt: Select[Any],
+    *,
+    as_of_date: date | None,
+    cik: str | None,
+    form_types: frozenset[str] | None,
+    section_labels: frozenset[str] | None,
+) -> Select[Any]:
+    """Add the shared retrieval filters to ``stmt``.
+
+    Exposed at module scope so tests can compile the resulting SQL and
+    assert against the WHERE clauses without booting a database.
+    """
+
+    if as_of_date is not None:
+        stmt = stmt.where(Filing.filing_date <= as_of_date)
+    if cik is not None:
+        stmt = stmt.where(Company.cik == cik.strip().zfill(10))
+    if form_types is not None:
+        stmt = stmt.where(Filing.form.in_(form_types))
+    if section_labels is not None:
+        stmt = stmt.where(FilingChunk.section_label.in_(section_labels))
+    return stmt
+
+
+def _row_to_result(row: Any, *, score: float) -> RetrievalResult:
+    return RetrievalResult(
+        chunk_id=row[0],
+        filing_document_id=row[1],
+        section_label=row[2],
+        section_title=row[3],
+        chunk_index=row[4],
+        text=row[5],
+        filing_id=row[6],
+        form=row[7],
+        filing_date=row[8],
+        accession_number=row[9],
+        cik=row[10],
+        ticker=row[11],
+        company_name=row[12],
+        score=score,
+    )
+
+
+async def dense_search(
+    *,
+    session: AsyncSession,
+    embedder: Embedder,
+    query: str,
+    k: int = DEFAULT_TOP_K,
+    as_of_date: date | None = None,
+    cik: str | None = None,
+    form_types: frozenset[str] | None = None,
+    section_labels: frozenset[str] | None = None,
+) -> list[RetrievalResult]:
+    """Top-K chunks by cosine similarity to ``query``'s embedding.
+
+    The returned ``score`` is ``1 - cosine_distance`` so higher is better
+    — consistent with the other search functions. Chunks whose
+    ``embedding`` column is NULL are skipped (the HNSW index would skip
+    them too, but the explicit filter documents intent).
+    """
+
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+
+    [query_vec] = await embedder.embed([query])
+
+    distance = FilingChunk.embedding.cosine_distance(query_vec)
+    stmt = _base_select(distance)
+    stmt = _apply_filters(
+        stmt,
+        as_of_date=as_of_date,
+        cik=cik,
+        form_types=form_types,
+        section_labels=section_labels,
+    )
+    stmt = stmt.where(FilingChunk.embedding.is_not(None)).order_by(distance.asc()).limit(k)
+
+    rows = (await session.execute(stmt)).all()
+    return [_row_to_result(row, score=1.0 - float(row[-1])) for row in rows]
+
+
+async def bm25_search(
+    *,
+    session: AsyncSession,
+    query: str,
+    k: int = DEFAULT_TOP_K,
+    as_of_date: date | None = None,
+    cik: str | None = None,
+    form_types: frozenset[str] | None = None,
+    section_labels: frozenset[str] | None = None,
+) -> list[RetrievalResult]:
+    """Top-K chunks by ``ts_rank_cd`` against a Postgres tsquery built from ``query``.
+
+    ``plainto_tsquery`` is used so callers can pass natural-language input
+    (it strips noise, applies the same stemming as the generated column,
+    and ANDs the remaining lexemes). The returned ``score`` is the raw
+    ``ts_rank_cd`` value; magnitudes are not directly comparable to cosine
+    similarity, which is exactly why hybrid search uses RRF rather than a
+    weighted sum.
+    """
+
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+
+    tsquery = func.plainto_tsquery(TSV_CONFIG, query)
+    rank_expr = func.ts_rank_cd(FilingChunk.text_tsv, tsquery)
+
+    stmt = _base_select(rank_expr)
+    stmt = _apply_filters(
+        stmt,
+        as_of_date=as_of_date,
+        cik=cik,
+        form_types=form_types,
+        section_labels=section_labels,
+    )
+    stmt = stmt.where(FilingChunk.text_tsv.op("@@")(tsquery)).order_by(desc(rank_expr)).limit(k)
+
+    rows = (await session.execute(stmt)).all()
+    return [_row_to_result(row, score=float(row[-1])) for row in rows]
+
+
+async def hybrid_search(
+    *,
+    session: AsyncSession,
+    embedder: Embedder,
+    query: str,
+    k: int = DEFAULT_TOP_K,
+    dense_candidates: int = DEFAULT_CANDIDATES,
+    bm25_candidates: int = DEFAULT_CANDIDATES,
+    rrf_k: int = DEFAULT_RRF_K,
+    as_of_date: date | None = None,
+    cik: str | None = None,
+    form_types: frozenset[str] | None = None,
+    section_labels: frozenset[str] | None = None,
+) -> list[RetrievalResult]:
+    """Top-K chunks fused from dense and BM25 rankings via RRF.
+
+    Pulls ``dense_candidates`` from :func:`dense_search` and
+    ``bm25_candidates`` from :func:`bm25_search`, fuses by RRF, and returns
+    the top ``k``. Each result carries the original per-retriever ranks
+    (``dense_rank``, ``bm25_rank``) for debuggability; ``None`` means the
+    chunk did not appear in that retriever's candidate set.
+    """
+
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+
+    dense = await dense_search(
+        session=session,
+        embedder=embedder,
+        query=query,
+        k=dense_candidates,
+        as_of_date=as_of_date,
+        cik=cik,
+        form_types=form_types,
+        section_labels=section_labels,
+    )
+    bm25 = await bm25_search(
+        session=session,
+        query=query,
+        k=bm25_candidates,
+        as_of_date=as_of_date,
+        cik=cik,
+        form_types=form_types,
+        section_labels=section_labels,
+    )
+
+    dense_ids = [r.chunk_id for r in dense]
+    bm25_ids = [r.chunk_id for r in bm25]
+    fused = reciprocal_rank_fusion([dense_ids, bm25_ids], k=rrf_k)
+
+    dense_rank = {cid: i + 1 for i, cid in enumerate(dense_ids)}
+    bm25_rank = {cid: i + 1 for i, cid in enumerate(bm25_ids)}
+
+    # Result hydration: prefer the dense-side object since dense_search
+    # populated it most recently; fall back to bm25 for chunks only the
+    # keyword side surfaced.
+    by_id: dict[int, RetrievalResult] = {r.chunk_id: r for r in bm25}
+    by_id.update({r.chunk_id: r for r in dense})
+
+    results: list[RetrievalResult] = []
+    for chunk_id, fused_score in fused[:k]:
+        base = by_id[chunk_id]
+        results.append(
+            replace(
+                base,
+                score=fused_score,
+                dense_rank=dense_rank.get(chunk_id),
+                bm25_rank=bm25_rank.get(chunk_id),
+            )
+        )
+
+    logger.info(
+        "hybrid_search query=%r dense=%d bm25=%d fused=%d returned=%d",
+        query,
+        len(dense),
+        len(bm25),
+        len(fused),
+        len(results),
+    )
+    return results
+
+
+__all__ = [
+    "DEFAULT_CANDIDATES",
+    "DEFAULT_TOP_K",
+    "bm25_search",
+    "dense_search",
+    "hybrid_search",
+]

--- a/tests/unit/chunking/test_chunker.py
+++ b/tests/unit/chunking/test_chunker.py
@@ -1,0 +1,165 @@
+"""Unit tests for the paragraph-aware chunker."""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import pytest
+
+from alphamind.chunking.chunker import (
+    DEFAULT_MAX_CHARS,
+    DEFAULT_OVERLAP_CHARS,
+    Chunk,
+    chunk_filing,
+    chunk_text,
+)
+
+
+def test_chunk_text_returns_single_chunk_when_under_budget() -> None:
+    text = "Paragraph one.\n\nParagraph two."
+
+    chunks = chunk_text(text, max_chars=1000, overlap_chars=100)
+
+    assert chunks == ["Paragraph one.\n\nParagraph two."]
+
+
+def test_chunk_text_returns_empty_list_for_empty_input() -> None:
+    assert chunk_text("", max_chars=1000, overlap_chars=100) == []
+    assert chunk_text("   \n\n   ", max_chars=1000, overlap_chars=100) == []
+
+
+def test_chunk_text_respects_max_chars() -> None:
+    paragraphs = [f"Paragraph {i} with some filler text to add length." for i in range(20)]
+    text = "\n\n".join(paragraphs)
+
+    chunks = chunk_text(text, max_chars=200, overlap_chars=50)
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert len(chunk) <= 200
+
+
+def test_chunk_text_includes_overlap_between_consecutive_chunks() -> None:
+    paragraphs = [f"Paragraph number {i}." for i in range(30)]
+    text = "\n\n".join(paragraphs)
+
+    chunks = chunk_text(text, max_chars=120, overlap_chars=40)
+
+    assert len(chunks) > 1
+    for prev, curr in pairwise(chunks):
+        # The overlap is paragraph-aligned, so at least one short paragraph
+        # from the end of the previous chunk should reappear in the next.
+        assert any(p in curr[:80] for p in prev.split("\n\n")[-2:]), (
+            f"no overlap between\n{prev!r}\nand\n{curr!r}"
+        )
+
+
+def test_chunk_text_splits_oversize_paragraph_on_sentence_boundaries() -> None:
+    sentence = "This is a single sentence with enough words to matter. "
+    long_paragraph = sentence * 20  # ~1100 chars, no internal paragraph break
+
+    chunks = chunk_text(long_paragraph, max_chars=200, overlap_chars=20)
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert len(chunk) <= 200
+    # Sentence boundaries are preserved: every chunk should end with
+    # terminal punctuation (allowing trailing whitespace).
+    for chunk in chunks:
+        assert chunk.rstrip().endswith((".", "!", "?"))
+
+
+def test_chunk_text_falls_back_to_word_split_for_giant_sentence() -> None:
+    giant_sentence = "alpha bravo charlie delta echo " * 100  # ~3000 chars, one "sentence"
+
+    chunks = chunk_text(giant_sentence, max_chars=150, overlap_chars=30)
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert len(chunk) <= 150
+
+
+def test_chunk_text_rejects_invalid_parameters() -> None:
+    with pytest.raises(ValueError, match="max_chars"):
+        chunk_text("hello", max_chars=0, overlap_chars=0)
+    with pytest.raises(ValueError, match="overlap_chars"):
+        chunk_text("hello", max_chars=100, overlap_chars=-1)
+    with pytest.raises(ValueError, match="overlap_chars"):
+        chunk_text("hello", max_chars=100, overlap_chars=100)
+
+
+def test_chunk_text_defaults_round_trip_small_text() -> None:
+    text = "Just a sentence."
+    chunks = chunk_text(text, max_chars=DEFAULT_MAX_CHARS, overlap_chars=DEFAULT_OVERLAP_CHARS)
+    assert chunks == [text]
+
+
+def test_chunk_filing_emits_chunks_with_section_metadata() -> None:
+    html = b"""
+    <html><body>
+      <p>Item 1. Business</p>
+      <p>We design and sell widgets to enterprises worldwide.</p>
+      <p>Our segments include software, services, and hardware.</p>
+      <p>Item 1A. Risk Factors</p>
+      <p>Customer concentration is a material risk.</p>
+      <p>Macroeconomic conditions may affect demand.</p>
+    </body></html>
+    """
+
+    chunks = chunk_filing(html, max_chars=500, overlap_chars=50)
+
+    assert len(chunks) >= 2
+    assert chunks[0].section_label == "item_1"
+    assert chunks[0].section_title == "Business"
+    assert chunks[0].chunk_index == 0
+    assert "widgets" in chunks[0].text
+
+    risk_chunks = [c for c in chunks if c.section_label == "item_1a"]
+    assert risk_chunks
+    assert risk_chunks[0].section_title == "Risk Factors"
+
+
+def test_chunk_filing_indexes_chunks_globally_in_reading_order() -> None:
+    paragraphs = [f"Filler paragraph number {i}." for i in range(50)]
+    body = "\n\n".join(paragraphs)
+    html = f"""
+    <html><body>
+      <p>Item 1. Business</p>
+      <p>{body}</p>
+      <p>Item 1A. Risk Factors</p>
+      <p>Single short risk paragraph.</p>
+    </body></html>
+    """.encode()
+
+    chunks = chunk_filing(html, max_chars=300, overlap_chars=50)
+
+    indices = [c.chunk_index for c in chunks]
+    assert indices == list(range(len(chunks)))
+
+
+def test_chunk_filing_chunk_count_matches_char_count_field() -> None:
+    html = b"<html><body><p>Item 1. Business</p><p>Short body paragraph.</p></body></html>"
+
+    chunks = chunk_filing(html)
+
+    assert chunks
+    for chunk in chunks:
+        assert chunk.char_count == len(chunk.text)
+
+
+def test_chunk_is_immutable() -> None:
+    chunk = Chunk(
+        section_label="item_1",
+        section_title="Business",
+        chunk_index=0,
+        text="hello",
+        char_count=5,
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        chunk.chunk_index = 99  # type: ignore[misc]
+
+
+def test_chunk_filing_returns_empty_for_documents_with_no_text() -> None:
+    html = b"<html><body><style>p{color:red}</style></body></html>"
+
+    assert chunk_filing(html) == []

--- a/tests/unit/chunking/test_parser.py
+++ b/tests/unit/chunking/test_parser.py
@@ -1,0 +1,192 @@
+"""Unit tests for the filing HTML parser."""
+
+from __future__ import annotations
+
+from alphamind.chunking.parser import (
+    PREAMBLE_LABEL,
+    detect_sections,
+    parse_filing_html,
+)
+
+
+def test_parse_filing_html_extracts_paragraphs_in_reading_order() -> None:
+    html = b"""
+    <html><body>
+        <p>First paragraph.</p>
+        <p>Second paragraph.</p>
+        <div>Third block.</div>
+    </body></html>
+    """
+
+    paragraphs = parse_filing_html(html)
+
+    assert paragraphs == ["First paragraph.", "Second paragraph.", "Third block."]
+
+
+def test_parse_filing_html_drops_scripts_styles_and_noscript() -> None:
+    html = b"""
+    <html>
+      <head><style>body{color:red}</style></head>
+      <body>
+        <script>alert('x')</script>
+        <noscript>JS required</noscript>
+        <p>Visible body.</p>
+      </body>
+    </html>
+    """
+
+    paragraphs = parse_filing_html(html)
+
+    assert paragraphs == ["Visible body."]
+
+
+def test_parse_filing_html_collapses_whitespace() -> None:
+    """Whitespace inside a single block (including source newlines) is collapsed."""
+
+    html = b"<p>Spaced\n\n\tout   text\nhere.</p>"
+
+    paragraphs = parse_filing_html(html)
+
+    # HTML treats source newlines and tabs as ordinary whitespace, so the
+    # whole ``<p>`` is one paragraph with internal whitespace collapsed.
+    assert paragraphs == ["Spaced out text here."]
+
+
+def test_parse_filing_html_promotes_br_to_paragraph_break() -> None:
+    html = b"<p>Line one.<br>Line two.<br/>Line three.</p>"
+
+    paragraphs = parse_filing_html(html)
+
+    assert paragraphs == ["Line one.", "Line two.", "Line three."]
+
+
+def test_parse_filing_html_handles_inline_xbrl() -> None:
+    """Inline-XBRL ``<ix:...>`` tags are passed through as ordinary text."""
+
+    html = b"""
+    <html><body>
+      <p>Revenue was <ix:nonNumeric name="us-gaap:Revenue">$1.0 billion</ix:nonNumeric>.</p>
+    </body></html>
+    """
+
+    paragraphs = parse_filing_html(html)
+
+    # lxml normalizes the inline-XBRL element but its text content survives.
+    assert paragraphs == ["Revenue was $1.0 billion ."]
+
+
+def test_detect_sections_groups_paragraphs_by_item_heading() -> None:
+    paragraphs = [
+        "Item 1. Business",
+        "We make computers.",
+        "Our segments are diverse.",
+        "Item 1A. Risk Factors",
+        "Risk one.",
+        "Risk two.",
+    ]
+
+    sections = detect_sections(paragraphs)
+
+    labels = [s.label for s in sections]
+    assert labels == ["item_1", "item_1a"]
+
+    business = sections[0]
+    assert business.title == "Business"
+    assert business.paragraphs == ["We make computers.", "Our segments are diverse."]
+
+    risk = sections[1]
+    assert risk.title == "Risk Factors"
+    assert risk.paragraphs == ["Risk one.", "Risk two."]
+
+
+def test_detect_sections_preserves_preamble() -> None:
+    paragraphs = [
+        "Some boilerplate before the first item.",
+        "More cover-page text.",
+        "Item 1. Business",
+        "Body.",
+    ]
+
+    sections = detect_sections(paragraphs)
+
+    assert sections[0].label == PREAMBLE_LABEL
+    assert sections[0].paragraphs == [
+        "Some boilerplate before the first item.",
+        "More cover-page text.",
+    ]
+    assert sections[1].label == "item_1"
+
+
+def test_detect_sections_drops_empty_preamble() -> None:
+    paragraphs = ["Item 1. Business", "Body content."]
+
+    sections = detect_sections(paragraphs)
+
+    assert [s.label for s in sections] == ["item_1"]
+
+
+def test_detect_sections_dedupes_toc_against_body() -> None:
+    """When ``Item N`` appears twice, the longer occurrence wins.
+
+    Real filings repeat every item label in their table of contents at the
+    top of the document, then again where the actual section starts. We
+    keep the body (large), not the TOC (small).
+    """
+
+    paragraphs = [
+        "Table of Contents",
+        "Item 1. Business",
+        "Item 1A. Risk Factors",
+        # The body of Item 1 follows with substantive text.
+        "Item 1. Business",
+        "We design, manufacture and market consumer electronics.",
+        "Our products include phones, tablets, and personal computers.",
+        "Our research and development efforts focus on next-generation devices.",
+        "Item 1A. Risk Factors",
+        "Our business is subject to a variety of risks including supply-chain disruption.",
+        "We face significant competition in every market we operate in.",
+    ]
+
+    sections = detect_sections(paragraphs)
+
+    labels = [s.label for s in sections]
+    assert labels == ["preamble", "item_1", "item_1a"]
+
+    item_1 = next(s for s in sections if s.label == "item_1")
+    assert any("consumer electronics" in p for p in item_1.paragraphs)
+    # The TOC version, which had zero body paragraphs, is gone.
+    assert len(item_1.paragraphs) == 3
+
+
+def test_detect_sections_recognises_part_and_dotted_items() -> None:
+    paragraphs = [
+        "Part II. Other Information",
+        "Item 5.07 Submission of Matters to a Vote of Security Holders",
+        "At the annual meeting, the following matters were submitted.",
+        "Item 9.01 Financial Statements and Exhibits",
+        "Exhibit 99.1 is attached hereto.",
+    ]
+
+    sections = detect_sections(paragraphs)
+
+    labels = [s.label for s in sections]
+    assert labels == ["part_ii", "item_5.07", "item_9.01"]
+
+
+def test_detect_sections_ignores_item_mentions_in_body_prose() -> None:
+    """A long sentence that happens to start with 'Item 1' is not a heading."""
+
+    paragraphs = [
+        "Item 1. Business",
+        # 250+ chars of prose; mentions 'Item' but is plainly not a heading.
+        "Item 1 of this report is intended to summarize our business and its "
+        "principal segments. We organize our internal reporting around three "
+        "operating units, each of which manages its own product roadmap and "
+        "go-to-market strategy. The discussion that follows draws on management's "
+        "current expectations and is subject to risks described elsewhere.",
+    ]
+
+    sections = detect_sections(paragraphs)
+
+    assert [s.label for s in sections] == ["item_1"]
+    assert len(sections[0].paragraphs) == 1

--- a/tests/unit/chunking/test_service.py
+++ b/tests/unit/chunking/test_service.py
@@ -1,0 +1,179 @@
+"""Unit tests for the chunking persistence service.
+
+These tests exercise :func:`chunk_filing_document` against a real on-disk
+:class:`LocalFilesystemStorage` (so byte fetches are end-to-end) and a
+hand-rolled fake :class:`AsyncSession` that captures issued statements
+without needing a live Postgres. Behaviour-of-the-upsert tests belong in
+integration; here we only verify the service's control flow.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from alphamind.chunking.service import chunk_filing_document
+from alphamind.models.filing_document import FilingDocument
+from alphamind.storage.local import LocalFilesystemStorage
+
+pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class FakeResult:
+    """Minimal stand-in for SQLAlchemy's Result — only the methods we use."""
+
+    value: Any = None
+
+    def scalar_one(self) -> Any:
+        return self.value
+
+
+class FakeSession:
+    """Session double that returns canned counts for ``SELECT`` and records writes."""
+
+    def __init__(self, *, existing_chunk_count: int = 0) -> None:
+        self._existing_chunk_count = existing_chunk_count
+        self.executed: list[Any] = []
+
+    async def execute(self, stmt: Any) -> FakeResult:
+        self.executed.append(stmt)
+        stmt_str = str(stmt).strip().lower()
+        if stmt_str.startswith("select"):
+            return FakeResult(value=self._existing_chunk_count)
+        return FakeResult()
+
+
+async def _seed_body(tmp_path: Path, body: bytes) -> tuple[LocalFilesystemStorage, str, str]:
+    storage = LocalFilesystemStorage(root=tmp_path)
+    digest = hashlib.sha256(body).hexdigest()
+    uri = await storage.put(key=digest, data=body)
+    return storage, uri, digest
+
+
+def _make_document(*, doc_id: int, storage_uri: str, content_hash: str) -> FilingDocument:
+    doc = FilingDocument()
+    doc.id = doc_id
+    doc.filing_id = 1
+    doc.storage_uri = storage_uri
+    doc.content_hash = content_hash
+    doc.byte_size = 0
+    doc.content_type = "text/html"
+    doc.source_url = "https://www.sec.gov/Archives/..."
+    return doc
+
+
+def _count_kind(executed: list[Any], kind: str) -> int:
+    return sum(1 for s in executed if str(s).strip().lower().startswith(kind))
+
+
+async def test_chunks_new_document_writes_rows(tmp_path: Path) -> None:
+    body = (
+        b"<html><body>"
+        b"<p>Item 1. Business</p>"
+        b"<p>We design and sell widgets globally.</p>"
+        b"<p>Our segments include software and hardware.</p>"
+        b"</body></html>"
+    )
+    storage, uri, digest = await _seed_body(tmp_path, body)
+    document = _make_document(doc_id=7, storage_uri=uri, content_hash=digest)
+    session = FakeSession(existing_chunk_count=0)
+
+    result = await chunk_filing_document(
+        storage=storage,
+        session=session,  # type: ignore[arg-type]
+        document=document,
+    )
+
+    assert result.was_skipped is False
+    assert result.chunks_written >= 1
+    # One SELECT (count), one DELETE, one INSERT.
+    assert _count_kind(session.executed, "select") == 1
+    assert _count_kind(session.executed, "delete") == 1
+    assert _count_kind(session.executed, "insert") == 1
+
+
+async def test_skips_when_hash_already_chunked(tmp_path: Path) -> None:
+    body = b"<html><body><p>Item 1. Business</p><p>Body.</p></body></html>"
+    storage, uri, digest = await _seed_body(tmp_path, body)
+    document = _make_document(doc_id=7, storage_uri=uri, content_hash=digest)
+    # Pretend filing_chunks already has rows for this (doc_id, content_hash).
+    session = FakeSession(existing_chunk_count=4)
+
+    result = await chunk_filing_document(
+        storage=storage,
+        session=session,  # type: ignore[arg-type]
+        document=document,
+    )
+
+    assert result.was_skipped is True
+    assert result.chunks_written == 0
+    # Only the count SELECT runs; no DELETE/INSERT.
+    assert _count_kind(session.executed, "select") == 1
+    assert _count_kind(session.executed, "delete") == 0
+    assert _count_kind(session.executed, "insert") == 0
+
+
+async def test_force_rechunks_even_when_hash_matches(tmp_path: Path) -> None:
+    body = b"<html><body><p>Item 1. Business</p><p>Body content here.</p></body></html>"
+    storage, uri, digest = await _seed_body(tmp_path, body)
+    document = _make_document(doc_id=7, storage_uri=uri, content_hash=digest)
+    session = FakeSession(existing_chunk_count=4)
+
+    result = await chunk_filing_document(
+        storage=storage,
+        session=session,  # type: ignore[arg-type]
+        document=document,
+        force=True,
+    )
+
+    assert result.was_skipped is False
+    assert result.chunks_written >= 1
+    # ``force=True`` skips the count SELECT entirely.
+    assert _count_kind(session.executed, "select") == 0
+    assert _count_kind(session.executed, "delete") == 1
+    assert _count_kind(session.executed, "insert") == 1
+
+
+async def test_rechunks_when_no_matching_hash_exists(tmp_path: Path) -> None:
+    """Body in storage is unchanged but the prior chunks were derived from
+    a different hash, so the count query returns zero and we re-chunk."""
+
+    body = b"<html><body><p>Item 1. Business</p><p>Body paragraph.</p></body></html>"
+    storage, uri, digest = await _seed_body(tmp_path, body)
+    document = _make_document(doc_id=7, storage_uri=uri, content_hash=digest)
+    session = FakeSession(existing_chunk_count=0)
+
+    result = await chunk_filing_document(
+        storage=storage,
+        session=session,  # type: ignore[arg-type]
+        document=document,
+    )
+
+    assert result.was_skipped is False
+    assert result.chunks_written >= 1
+    assert _count_kind(session.executed, "delete") == 1
+    assert _count_kind(session.executed, "insert") == 1
+
+
+async def test_writes_no_rows_when_body_has_no_text(tmp_path: Path) -> None:
+    body = b"<html><body><style>p{color:red}</style></body></html>"
+    storage, uri, digest = await _seed_body(tmp_path, body)
+    document = _make_document(doc_id=7, storage_uri=uri, content_hash=digest)
+    session = FakeSession(existing_chunk_count=0)
+
+    result = await chunk_filing_document(
+        storage=storage,
+        session=session,  # type: ignore[arg-type]
+        document=document,
+    )
+
+    assert result.was_skipped is False
+    assert result.chunks_written == 0
+    # DELETE still runs (clears any stale rows); no INSERT because no chunks.
+    assert _count_kind(session.executed, "delete") == 1
+    assert _count_kind(session.executed, "insert") == 0

--- a/tests/unit/embeddings/test_deterministic.py
+++ b/tests/unit/embeddings/test_deterministic.py
@@ -1,0 +1,105 @@
+"""Unit tests for the deterministic hash-based embedder.
+
+These tests pin the contract the rest of the system relies on:
+
+- Output dimension equals the declared dimension.
+- Vectors are L2-normalised so cosine similarity is well defined.
+- Encoding is stable across calls for identical inputs.
+- Texts that share more tokens have higher cosine similarity than
+  unrelated texts (weak but non-trivial structure).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alphamind.embeddings.deterministic import (
+    DEFAULT_DIMENSION,
+    DeterministicEmbedder,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b, strict=True))
+
+
+async def test_dimension_and_model_name_match_declared_values() -> None:
+    embedder = DeterministicEmbedder(dimension=64)
+
+    assert embedder.dimension == 64
+    assert embedder.model_name == "deterministic-hash-64"
+
+    vectors = await embedder.embed(["hello world"])
+    assert len(vectors) == 1
+    assert len(vectors[0]) == 64
+
+
+async def test_default_dimension_matches_module_constant() -> None:
+    embedder = DeterministicEmbedder()
+
+    assert embedder.dimension == DEFAULT_DIMENSION
+    # Pinned to 768 to match Gemini's text-embedding-004 and the schema.
+    assert DEFAULT_DIMENSION == 768
+
+
+async def test_vectors_are_l2_normalised() -> None:
+    embedder = DeterministicEmbedder(dimension=128)
+
+    [vec] = await embedder.embed(["this is a non-trivial sentence with several words"])
+    norm = math.sqrt(sum(v * v for v in vec))
+
+    assert math.isclose(norm, 1.0, rel_tol=1e-9)
+
+
+async def test_encoding_is_deterministic_across_calls() -> None:
+    embedder = DeterministicEmbedder(dimension=64)
+
+    [first] = await embedder.embed(["AlphaMind chunk text"])
+    [second] = await embedder.embed(["AlphaMind chunk text"])
+
+    assert first == second
+
+
+async def test_order_is_preserved_within_a_batch() -> None:
+    embedder = DeterministicEmbedder(dimension=32)
+
+    texts = ["alpha", "beta", "gamma"]
+    vectors = await embedder.embed(texts)
+
+    # Compare against per-text encodings to confirm position is stable.
+    individual = [(await embedder.embed([t]))[0] for t in texts]
+    assert vectors == individual
+
+
+async def test_shared_tokens_yield_higher_similarity_than_unrelated_text() -> None:
+    embedder = DeterministicEmbedder(dimension=512)
+
+    [a, b, c] = await embedder.embed(
+        [
+            "revenue from cloud services grew this quarter",
+            "revenue from cloud services declined this quarter",
+            "the cat sat quietly on the windowsill at dusk",
+        ]
+    )
+
+    sim_ab = _cosine(a, b)  # heavy token overlap
+    sim_ac = _cosine(a, c)  # essentially no overlap
+
+    assert sim_ab > sim_ac
+
+
+async def test_empty_text_yields_zero_vector() -> None:
+    embedder = DeterministicEmbedder(dimension=32)
+
+    [vec] = await embedder.embed([""])
+
+    assert vec == [0.0] * 32
+
+
+async def test_rejects_non_positive_dimension() -> None:
+    with pytest.raises(ValueError, match="dimension must be positive"):
+        DeterministicEmbedder(dimension=0)

--- a/tests/unit/embeddings/test_factory.py
+++ b/tests/unit/embeddings/test_factory.py
@@ -1,0 +1,83 @@
+"""Unit tests for :func:`get_embedder`."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from alphamind.config import Settings, get_settings
+from alphamind.embeddings import factory
+from alphamind.embeddings.base import EmbedderError
+from alphamind.embeddings.deterministic import DeterministicEmbedder
+from alphamind.embeddings.gemini import GeminiEmbedder
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> Iterator[None]:
+    get_settings.cache_clear()
+    factory.get_embedder.cache_clear()
+    yield
+    get_settings.cache_clear()
+    factory.get_embedder.cache_clear()
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "database_url": "postgresql+asyncpg://x/y",
+        "redis_url": "redis://localhost:6379/0",
+        "sec_user_agent": "AlphaMind test test@example.com",
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def test_returns_deterministic_when_backend_is_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        factory,
+        "get_settings",
+        lambda: _settings(embedder_backend="deterministic", embedder_dimension=128),
+    )
+
+    embedder = factory.get_embedder()
+
+    assert isinstance(embedder, DeterministicEmbedder)
+    assert embedder.dimension == 128
+
+
+def test_returns_gemini_when_backend_and_key_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        factory,
+        "get_settings",
+        lambda: _settings(
+            embedder_backend="gemini",
+            google_api_key="sk-test",
+            embedder_dimension=768,
+        ),
+    )
+
+    embedder = factory.get_embedder()
+
+    try:
+        assert isinstance(embedder, GeminiEmbedder)
+        assert embedder.dimension == 768
+        assert embedder.model_name == "gemini:text-embedding-004"
+    finally:
+        # The factory cached this instance; clear before the next test so
+        # its httpx client gets closed via dispose_embedder below.
+        pass
+
+
+def test_gemini_backend_without_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        factory,
+        "get_settings",
+        lambda: _settings(embedder_backend="gemini", google_api_key=None),
+    )
+
+    with pytest.raises(EmbedderError, match="GOOGLE_API_KEY"):
+        factory.get_embedder()

--- a/tests/unit/embeddings/test_gemini.py
+++ b/tests/unit/embeddings/test_gemini.py
@@ -1,0 +1,179 @@
+"""Unit tests for :class:`GeminiEmbedder`.
+
+The embedder talks to Google's REST API; we mock the wire with respx so
+no network call ever leaves the process. Tests cover the happy path, the
+request shape Google expects, batching beyond ``MAX_BATCH_SIZE``, retry
+on 429, and parsing failures.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+import httpx
+import pytest
+import respx
+
+from alphamind.embeddings.base import EmbedderError
+from alphamind.embeddings.gemini import (
+    GEMINI_API_BASE,
+    MAX_BATCH_SIZE,
+    GeminiEmbedder,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_API_KEY = "test-key"
+_MODEL = "text-embedding-004"
+_URL = f"{GEMINI_API_BASE}/models/{_MODEL}:batchEmbedContents"
+
+
+def _payload(*vectors: Iterable[float]) -> dict[str, object]:
+    return {"embeddings": [{"values": list(v)} for v in vectors]}
+
+
+async def test_embed_returns_vectors_in_input_order() -> None:
+    embedder = GeminiEmbedder(api_key=_API_KEY, dimension=3, rate=1000)
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            mock.post(_URL).respond(
+                json=_payload([0.1, 0.2, 0.3], [0.4, 0.5, 0.6]),
+            )
+
+            vectors = await embedder.embed(["alpha", "beta"])
+
+        assert vectors == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_sends_api_key_and_correct_request_shape() -> None:
+    embedder = GeminiEmbedder(api_key=_API_KEY, dimension=3, rate=1000)
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            route = mock.post(_URL).respond(json=_payload([0.0, 0.0, 0.0]))
+
+            await embedder.embed(["hello"])
+
+            request = route.calls.last.request
+            assert request.url.params["key"] == _API_KEY
+            body = json.loads(request.content)
+            assert body == {
+                "requests": [
+                    {
+                        "model": f"models/{_MODEL}",
+                        "content": {"parts": [{"text": "hello"}]},
+                    }
+                ]
+            }
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_empty_input_does_not_call_api() -> None:
+    embedder = GeminiEmbedder(api_key=_API_KEY, dimension=3)
+    try:
+        async with respx.mock(assert_all_called=False) as mock:
+            route = mock.post(_URL)
+            vectors = await embedder.embed([])
+
+        assert vectors == []
+        assert route.call_count == 0
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_slices_into_multiple_batches_when_over_max() -> None:
+    n = MAX_BATCH_SIZE + 5
+    embedder = GeminiEmbedder(api_key=_API_KEY, dimension=2, rate=1000)
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            route = mock.post(_URL).mock(
+                side_effect=[
+                    httpx.Response(200, json=_payload(*[[1.0, 1.0]] * MAX_BATCH_SIZE)),
+                    httpx.Response(200, json=_payload(*[[2.0, 2.0]] * 5)),
+                ]
+            )
+
+            vectors = await embedder.embed([f"t{i}" for i in range(n)])
+
+        assert route.call_count == 2
+        assert len(vectors) == n
+        assert vectors[0] == [1.0, 1.0]
+        assert vectors[-1] == [2.0, 2.0]
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_retries_on_429_then_succeeds() -> None:
+    embedder = GeminiEmbedder(
+        api_key=_API_KEY,
+        dimension=2,
+        rate=1000,
+        max_retries=3,
+    )
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            route = mock.post(_URL).mock(
+                side_effect=[
+                    httpx.Response(429),
+                    httpx.Response(200, json=_payload([0.5, 0.5])),
+                ]
+            )
+
+            vectors = await embedder.embed(["please"])
+
+        assert route.call_count == 2
+        assert vectors == [[0.5, 0.5]]
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_raises_embedder_error_on_persistent_4xx() -> None:
+    embedder = GeminiEmbedder(
+        api_key=_API_KEY,
+        dimension=2,
+        rate=1000,
+        max_retries=2,
+    )
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            mock.post(_URL).respond(status_code=400, text="bad request")
+
+            with pytest.raises(EmbedderError, match="gemini embed failed"):
+                await embedder.embed(["nope"])
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_raises_embedder_error_when_response_shape_is_wrong() -> None:
+    embedder = GeminiEmbedder(api_key=_API_KEY, dimension=2, rate=1000)
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            mock.post(_URL).respond(json={"embeddings": [{"values": [0.1]}]})
+
+            # We asked for 2 vectors but Google returned 1.
+            with pytest.raises(EmbedderError, match="expected 2 embeddings"):
+                await embedder.embed(["a", "b"])
+    finally:
+        await embedder.aclose()
+
+
+async def test_model_name_includes_model_path() -> None:
+    embedder = GeminiEmbedder(api_key=_API_KEY, dimension=2)
+    try:
+        assert embedder.model_name == f"gemini:{_MODEL}"
+        assert embedder.dimension == 2
+    finally:
+        await embedder.aclose()
+
+
+async def test_rejects_empty_api_key() -> None:
+    with pytest.raises(ValueError, match="api_key must be non-empty"):
+        GeminiEmbedder(api_key="", dimension=2)
+
+
+async def test_rejects_non_positive_dimension() -> None:
+    with pytest.raises(ValueError, match="dimension must be positive"):
+        GeminiEmbedder(api_key=_API_KEY, dimension=0)

--- a/tests/unit/embeddings/test_service.py
+++ b/tests/unit/embeddings/test_service.py
@@ -1,0 +1,215 @@
+"""Unit tests for :func:`embed_chunks_for_document`.
+
+The service mutates :class:`FilingChunk` ORM objects in place; persistence
+happens via the session's autoflush. These tests use a fake session that
+returns a canned list of in-memory chunk objects and counts flushes —
+that's enough to verify the service's control flow without booting a
+database. Behaviour-of-the-vector-column tests belong in integration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from alphamind.embeddings.deterministic import DeterministicEmbedder
+from alphamind.embeddings.service import embed_chunks_for_document
+from alphamind.models.filing_chunk import FilingChunk
+
+pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class FakeScalars:
+    items: list[Any]
+
+    def __iter__(self) -> Any:
+        return iter(self.items)
+
+
+@dataclass
+class FakeResult:
+    items: list[Any]
+
+    def scalars(self) -> FakeScalars:
+        return FakeScalars(items=self.items)
+
+
+class FakeSession:
+    """Returns canned chunks for any ``select`` and tracks flush calls."""
+
+    def __init__(self, chunks: list[FilingChunk]) -> None:
+        self._chunks = chunks
+        self.flush_count = 0
+
+    async def execute(self, stmt: Any) -> FakeResult:
+        # The service issues exactly one SELECT — return all chunks.
+        return FakeResult(items=list(self._chunks))
+
+    async def flush(self) -> None:
+        self.flush_count += 1
+
+
+def _make_chunk(
+    *,
+    chunk_id: int,
+    text: str,
+    embedding: list[float] | None = None,
+    embedding_model: str | None = None,
+) -> FilingChunk:
+    chunk = FilingChunk()
+    chunk.id = chunk_id
+    chunk.filing_document_id = 1
+    chunk.section_label = "preamble"
+    chunk.section_title = None
+    chunk.chunk_index = chunk_id
+    chunk.text = text
+    chunk.char_count = len(text)
+    chunk.source_content_hash = "a" * 64
+    chunk.embedding = embedding
+    chunk.embedding_model = embedding_model
+    chunk.embedded_at = None
+    return chunk
+
+
+async def test_embeds_unembedded_chunks() -> None:
+    chunks = [
+        _make_chunk(chunk_id=1, text="first chunk"),
+        _make_chunk(chunk_id=2, text="second chunk"),
+    ]
+    session = FakeSession(chunks=chunks)
+    embedder = DeterministicEmbedder(dimension=32)
+
+    result = await embed_chunks_for_document(
+        session=session,  # type: ignore[arg-type]
+        embedder=embedder,
+        filing_document_id=1,
+    )
+
+    assert result.chunks_embedded == 2
+    assert result.chunks_skipped == 0
+    for chunk in chunks:
+        assert chunk.embedding is not None
+        assert len(chunk.embedding) == 32
+        assert chunk.embedding_model == embedder.model_name
+        assert chunk.embedded_at is not None
+
+
+async def test_skips_chunks_already_embedded_under_same_model() -> None:
+    embedder = DeterministicEmbedder(dimension=32)
+    fresh_vec = [0.1] * 32
+    chunks = [
+        _make_chunk(
+            chunk_id=1,
+            text="already done",
+            embedding=fresh_vec,
+            embedding_model=embedder.model_name,
+        ),
+        _make_chunk(chunk_id=2, text="needs embedding"),
+    ]
+    session = FakeSession(chunks=chunks)
+
+    result = await embed_chunks_for_document(
+        session=session,  # type: ignore[arg-type]
+        embedder=embedder,
+        filing_document_id=1,
+    )
+
+    assert result.chunks_embedded == 1
+    assert result.chunks_skipped == 1
+    # The pre-embedded chunk's vector was not overwritten.
+    assert chunks[0].embedding == fresh_vec
+
+
+async def test_re_embeds_chunks_under_different_model() -> None:
+    other_vec = [0.5] * 32
+    chunks = [
+        _make_chunk(
+            chunk_id=1,
+            text="needs re-embed",
+            embedding=other_vec,
+            embedding_model="some-other-model",
+        ),
+    ]
+    session = FakeSession(chunks=chunks)
+    embedder = DeterministicEmbedder(dimension=32)
+
+    result = await embed_chunks_for_document(
+        session=session,  # type: ignore[arg-type]
+        embedder=embedder,
+        filing_document_id=1,
+    )
+
+    assert result.chunks_embedded == 1
+    assert result.chunks_skipped == 0
+    assert chunks[0].embedding_model == embedder.model_name
+    assert chunks[0].embedding != other_vec
+
+
+async def test_force_re_embeds_chunks_under_same_model() -> None:
+    embedder = DeterministicEmbedder(dimension=32)
+    chunks = [
+        _make_chunk(
+            chunk_id=1,
+            text="reembed me",
+            embedding=[0.0] * 32,
+            embedding_model=embedder.model_name,
+        ),
+    ]
+    session = FakeSession(chunks=chunks)
+
+    result = await embed_chunks_for_document(
+        session=session,  # type: ignore[arg-type]
+        embedder=embedder,
+        filing_document_id=1,
+        force=True,
+    )
+
+    assert result.chunks_embedded == 1
+    assert result.chunks_skipped == 0
+
+
+async def test_flushes_once_per_batch() -> None:
+    chunks = [_make_chunk(chunk_id=i, text=f"chunk {i}") for i in range(5)]
+    session = FakeSession(chunks=chunks)
+    embedder = DeterministicEmbedder(dimension=16)
+
+    await embed_chunks_for_document(
+        session=session,  # type: ignore[arg-type]
+        embedder=embedder,
+        filing_document_id=1,
+        batch_size=2,
+    )
+
+    # 5 chunks, batch=2 -> batches of (2, 2, 1) -> 3 flushes.
+    assert session.flush_count == 3
+
+
+async def test_does_nothing_when_no_chunks_exist() -> None:
+    session = FakeSession(chunks=[])
+    embedder = DeterministicEmbedder(dimension=16)
+
+    result = await embed_chunks_for_document(
+        session=session,  # type: ignore[arg-type]
+        embedder=embedder,
+        filing_document_id=42,
+    )
+
+    assert result.chunks_embedded == 0
+    assert result.chunks_skipped == 0
+    assert session.flush_count == 0
+
+
+async def test_rejects_non_positive_batch_size() -> None:
+    session = FakeSession(chunks=[])
+    embedder = DeterministicEmbedder(dimension=16)
+
+    with pytest.raises(ValueError, match="batch_size must be positive"):
+        await embed_chunks_for_document(
+            session=session,  # type: ignore[arg-type]
+            embedder=embedder,
+            filing_document_id=1,
+            batch_size=0,
+        )

--- a/tests/unit/reranking/test_deterministic.py
+++ b/tests/unit/reranking/test_deterministic.py
@@ -1,0 +1,105 @@
+"""Unit tests for :class:`DeterministicReranker`.
+
+These pin the contract the rest of the system relies on:
+
+- Scoring is bounded (Jaccard ∈ [0, 1]) and deterministic across calls.
+- Higher token overlap with the query yields a higher score.
+- The returned list preserves every input chunk_id exactly once.
+- Tie-breaks fall back to input order.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alphamind.reranking.deterministic import DeterministicReranker
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_perfect_overlap_scores_one_no_overlap_scores_zero() -> None:
+    reranker = DeterministicReranker()
+    out = await reranker.rerank(
+        "alpha beta gamma",
+        [
+            (1, "alpha beta gamma"),
+            (2, "nothing in common here"),
+        ],
+    )
+
+    by_id = {r.chunk_id: r.score for r in out}
+    assert by_id[1] == pytest.approx(1.0)
+    assert by_id[2] == pytest.approx(0.0)
+
+
+async def test_more_overlap_outranks_less_overlap() -> None:
+    reranker = DeterministicReranker()
+    out = await reranker.rerank(
+        "supply chain risk semiconductor exposure",
+        [
+            (10, "semiconductor exposure was a key supply risk"),  # heavy overlap
+            (20, "we hosted an annual employee picnic"),  # essentially none
+            (30, "supply chain disruptions affected shipping"),  # partial overlap
+        ],
+    )
+
+    ordered_ids = [r.chunk_id for r in out]
+    assert ordered_ids[0] == 10
+    assert ordered_ids[-1] == 20
+
+
+async def test_returns_all_input_chunks_exactly_once() -> None:
+    reranker = DeterministicReranker()
+    inputs: list[tuple[int, str]] = [(i, f"chunk {i} text") for i in range(5)]
+
+    out = await reranker.rerank("chunk text", inputs)
+
+    assert {r.chunk_id for r in out} == {i for i, _ in inputs}
+    assert len(out) == len(inputs)
+
+
+async def test_tie_breaks_by_input_order() -> None:
+    reranker = DeterministicReranker()
+    # Two passages with the same token set → tied score → input order wins.
+    out = await reranker.rerank(
+        "alpha beta",
+        [
+            (100, "alpha beta"),
+            (200, "beta alpha"),
+        ],
+    )
+
+    assert [r.chunk_id for r in out] == [100, 200]
+
+
+async def test_empty_query_yields_zero_scores() -> None:
+    reranker = DeterministicReranker()
+    out = await reranker.rerank("", [(1, "some text"), (2, "other text")])
+
+    assert all(r.score == 0.0 for r in out)
+
+
+async def test_empty_passage_text_yields_zero_score() -> None:
+    reranker = DeterministicReranker()
+    out = await reranker.rerank("relevant query", [(1, "")])
+
+    assert out[0].chunk_id == 1
+    assert out[0].score == 0.0
+
+
+async def test_deterministic_across_repeated_calls() -> None:
+    reranker = DeterministicReranker()
+    passages: list[tuple[int, str]] = [
+        (1, "alpha beta"),
+        (2, "beta gamma"),
+        (3, "gamma delta"),
+    ]
+
+    first = await reranker.rerank("alpha", passages)
+    second = await reranker.rerank("alpha", passages)
+
+    assert [(r.chunk_id, r.score) for r in first] == [(r.chunk_id, r.score) for r in second]
+
+
+async def test_model_name_is_stable() -> None:
+    assert DeterministicReranker().model_name == "deterministic-jaccard"

--- a/tests/unit/reranking/test_factory.py
+++ b/tests/unit/reranking/test_factory.py
@@ -1,0 +1,65 @@
+"""Unit tests for :func:`get_reranker`."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+
+from alphamind.config import Settings, get_settings
+from alphamind.reranking import factory
+from alphamind.reranking.cross_encoder import CrossEncoderReranker
+from alphamind.reranking.deterministic import DeterministicReranker
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> Iterator[None]:
+    get_settings.cache_clear()
+    factory.get_reranker.cache_clear()
+    yield
+    get_settings.cache_clear()
+    factory.get_reranker.cache_clear()
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "database_url": "postgresql+asyncpg://x/y",
+        "redis_url": "redis://localhost:6379/0",
+        "sec_user_agent": "AlphaMind test test@example.com",
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def test_returns_deterministic_when_backend_is_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(factory, "get_settings", _settings)
+
+    reranker = factory.get_reranker()
+
+    assert isinstance(reranker, DeterministicReranker)
+
+
+def test_returns_cross_encoder_when_backend_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        factory,
+        "get_settings",
+        lambda: _settings(
+            reranker_backend="cross_encoder",
+            cross_encoder_model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        ),
+    )
+
+    reranker = factory.get_reranker()
+
+    # Don't trigger model load — just verify the wrapper was constructed.
+    assert isinstance(reranker, CrossEncoderReranker)
+    assert reranker.model_name == "cross-encoder:cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
+def test_dispose_is_safe_before_construction() -> None:
+    # Pre-condition: cache empty (the autouse fixture cleared it).
+    asyncio.run(factory.dispose_reranker())
+    assert factory.get_reranker.cache_info().currsize == 0

--- a/tests/unit/reranking/test_service.py
+++ b/tests/unit/reranking/test_service.py
@@ -1,0 +1,133 @@
+"""Unit tests for :func:`rerank_results`."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from alphamind.reranking.base import RerankedPassage
+from alphamind.reranking.service import rerank_results
+from alphamind.retrieval.results import RetrievalResult
+
+pytestmark = pytest.mark.asyncio
+
+
+def _result(chunk_id: int, score: float, *, dense_rank: int | None = None) -> RetrievalResult:
+    return RetrievalResult(
+        chunk_id=chunk_id,
+        filing_document_id=10 + chunk_id,
+        filing_id=100 + chunk_id,
+        cik="0000000001",
+        ticker="TST",
+        company_name="Test Co",
+        form="10-K",
+        filing_date=date(2025, 1, 1),
+        accession_number=f"0000000001-25-{chunk_id:06d}",
+        section_label="preamble",
+        section_title=None,
+        chunk_index=chunk_id,
+        text=f"text {chunk_id}",
+        score=score,
+        dense_rank=dense_rank,
+    )
+
+
+class _FakeReranker:
+    model_name = "fake"
+
+    def __init__(self, mapping: dict[int, float]) -> None:
+        self._mapping = mapping
+
+    async def rerank(
+        self,
+        query: str,
+        passages: list[tuple[int, str]],
+    ) -> list[RerankedPassage]:
+        scored = [RerankedPassage(chunk_id=cid, score=self._mapping[cid]) for cid, _ in passages]
+        scored.sort(key=lambda r: -r.score)
+        return scored
+
+
+async def test_replaces_score_and_resorts() -> None:
+    inputs = [_result(1, 0.9), _result(2, 0.8), _result(3, 0.7)]
+    reranker = _FakeReranker({1: 0.1, 2: 0.9, 3: 0.5})
+
+    out = await rerank_results(reranker=reranker, query="q", results=inputs)
+
+    assert [r.chunk_id for r in out] == [2, 3, 1]
+    assert [r.score for r in out] == [0.9, 0.5, 0.1]
+
+
+async def test_preserves_per_retriever_ranks() -> None:
+    inputs = [_result(1, 0.9, dense_rank=1), _result(2, 0.8, dense_rank=2)]
+    reranker = _FakeReranker({1: 0.2, 2: 0.8})
+
+    out = await rerank_results(reranker=reranker, query="q", results=inputs)
+
+    by_id = {r.chunk_id: r for r in out}
+    assert by_id[1].dense_rank == 1
+    assert by_id[2].dense_rank == 2
+
+
+async def test_truncates_to_top_k() -> None:
+    inputs = [_result(i, 0.0) for i in range(1, 6)]
+    reranker = _FakeReranker({i: float(i) for i in range(1, 6)})
+
+    out = await rerank_results(reranker=reranker, query="q", results=inputs, top_k=2)
+
+    assert len(out) == 2
+    assert [r.chunk_id for r in out] == [5, 4]
+
+
+async def test_empty_input_returns_empty_without_calling_reranker() -> None:
+    called = False
+
+    class TripwireReranker:
+        model_name = "tripwire"
+
+        async def rerank(
+            self,
+            query: str,
+            passages: list[tuple[int, str]],
+        ) -> list[RerankedPassage]:
+            nonlocal called
+            called = True
+            return []
+
+    out = await rerank_results(reranker=TripwireReranker(), query="q", results=[])
+
+    assert out == []
+    assert called is False
+
+
+async def test_rejects_non_positive_top_k() -> None:
+    with pytest.raises(ValueError, match="top_k must be positive"):
+        await rerank_results(
+            reranker=_FakeReranker({}),
+            query="q",
+            results=[_result(1, 0.5)],
+            top_k=0,
+        )
+
+
+async def test_skips_chunks_the_reranker_invents() -> None:
+    """If the reranker returns a chunk_id we did not pass in, skip it rather than crash."""
+
+    class GhostReranker:
+        model_name = "ghost"
+
+        async def rerank(
+            self,
+            query: str,
+            passages: list[tuple[int, str]],
+        ) -> list[RerankedPassage]:
+            return [
+                RerankedPassage(chunk_id=999, score=10.0),  # not in input
+                RerankedPassage(chunk_id=passages[0][0], score=1.0),
+            ]
+
+    inputs = [_result(7, 0.5)]
+    out = await rerank_results(reranker=GhostReranker(), query="q", results=inputs)
+
+    assert [r.chunk_id for r in out] == [7]

--- a/tests/unit/retrieval/test_fusion.py
+++ b/tests/unit/retrieval/test_fusion.py
@@ -1,0 +1,88 @@
+"""Unit tests for :func:`reciprocal_rank_fusion`.
+
+These pin the math contract the rest of retrieval relies on: items present
+in multiple rankings beat items present in only one; ties break by first-
+appearance order across the input rankings; absent items contribute 0.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alphamind.retrieval.fusion import DEFAULT_RRF_K, reciprocal_rank_fusion
+
+
+def test_single_ranking_preserves_order() -> None:
+    fused = reciprocal_rank_fusion([["a", "b", "c"]])
+
+    assert [item for item, _ in fused] == ["a", "b", "c"]
+
+
+def test_two_rankings_boost_overlapping_items() -> None:
+    # 'b' appears at rank 2 in both → highest fused score.
+    # 'a' appears only in the first ranking; 'c' only in the second.
+    fused = reciprocal_rank_fusion([["a", "b"], ["c", "b"]])
+    order = [item for item, _ in fused]
+
+    assert order[0] == "b"
+    # 'a' and 'c' tie on score (both at rank 1 in one ranking); first-seen
+    # order across inputs breaks the tie deterministically.
+    assert order[1] == "a"
+    assert order[2] == "c"
+
+
+def test_known_rrf_scores_with_default_k() -> None:
+    fused = dict(reciprocal_rank_fusion([["a", "b"]]))
+
+    assert math.isclose(fused["a"], 1.0 / (DEFAULT_RRF_K + 1))
+    assert math.isclose(fused["b"], 1.0 / (DEFAULT_RRF_K + 2))
+
+
+def test_item_present_in_two_rankings_outranks_first_in_one() -> None:
+    # 'a' is rank-1 in ranking A but absent from B.
+    # 'b' is rank-2 in A and rank-1 in B.
+    # Fused: a = 1/(60+1); b = 1/(60+2) + 1/(60+1). b wins.
+    fused = reciprocal_rank_fusion([["a", "b"], ["b"]])
+
+    order = [item for item, _ in fused]
+    assert order == ["b", "a"]
+
+
+def test_returns_empty_when_no_rankings() -> None:
+    assert reciprocal_rank_fusion([]) == []
+
+
+def test_returns_empty_when_all_rankings_empty() -> None:
+    assert reciprocal_rank_fusion([[], []]) == []
+
+
+def test_k_smoothing_flattens_top_rank_dominance() -> None:
+    # With small k the top of a ranking dominates; with huge k the
+    # contribution per position evens out, so the second-ranked-but-
+    # double-appearing item should win.
+    rankings = [["a", "b"], ["c", "b"]]
+
+    small_k = dict(reciprocal_rank_fusion(rankings, k=0))
+    large_k = dict(reciprocal_rank_fusion(rankings, k=10_000))
+
+    # At k=0, 'a' (rank 1 in one list, score=1) ties with 'c' (rank 1 in
+    # the other) and 'b' has 1/2 + 1/2 = 1, also tied. So all three are
+    # close in small_k; in large_k, 'b' wins decisively.
+    assert large_k["b"] > large_k["a"]
+    assert large_k["b"] > large_k["c"]
+    # And small_k still ranks 'b' at the top thanks to two contributions.
+    assert small_k["b"] >= small_k["a"]
+    assert small_k["b"] >= small_k["c"]
+
+
+def test_works_with_integer_chunk_ids() -> None:
+    fused = reciprocal_rank_fusion([[10, 20, 30], [30, 20]])
+    top_id, _ = fused[0]
+    assert top_id == 30
+
+
+def test_rejects_negative_k() -> None:
+    with pytest.raises(ValueError, match="k must be non-negative"):
+        reciprocal_rank_fusion([["a"]], k=-1)

--- a/tests/unit/retrieval/test_service.py
+++ b/tests/unit/retrieval/test_service.py
@@ -1,0 +1,243 @@
+"""Unit tests for the retrieval service.
+
+The retrieval SQL itself (cosine_distance, ts_rank_cd, GIN/HNSW indexes)
+needs a live Postgres with pgvector and so lives in integration tests.
+Here we cover the testable seams:
+
+- The shared filter helper builds the right WHERE clauses.
+- :func:`hybrid_search` correctly orchestrates dense + bm25 and fuses
+  their results — verified by monkey-patching the two sub-searches.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+from sqlalchemy import func
+
+from alphamind.retrieval import service as retrieval_service
+from alphamind.retrieval.results import RetrievalResult
+from alphamind.retrieval.service import (
+    _apply_filters,
+    _base_select,
+    hybrid_search,
+)
+
+# pytest-asyncio runs in auto mode (see pyproject.toml), so async tests in
+# this file are picked up without an explicit marker. Sync filter-builder
+# tests stay sync.
+
+
+def _compile(stmt: Any) -> str:
+    return str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+
+def test_apply_filters_no_args_emits_no_where() -> None:
+    base = _base_select(func.count())
+    stmt = _apply_filters(
+        base,
+        as_of_date=None,
+        cik=None,
+        form_types=None,
+        section_labels=None,
+    )
+
+    sql = _compile(stmt).lower()
+    # The base joins are still there; only the filter-derived WHERE
+    # clauses should be missing.
+    assert "filing_date" not in sql.split("where")[-1] if "where" in sql else True
+
+
+def test_apply_filters_as_of_date_clauses_filing_date() -> None:
+    base = _base_select(func.count())
+    stmt = _apply_filters(
+        base,
+        as_of_date=date(2025, 1, 1),
+        cik=None,
+        form_types=None,
+        section_labels=None,
+    )
+
+    sql = _compile(stmt).lower()
+    assert "filings.filing_date <=" in sql
+    assert "2025-01-01" in sql
+
+
+def test_apply_filters_cik_is_zero_padded() -> None:
+    base = _base_select(func.count())
+    stmt = _apply_filters(
+        base,
+        as_of_date=None,
+        cik="320193",  # Apple, 6 chars
+        form_types=None,
+        section_labels=None,
+    )
+
+    sql = _compile(stmt).lower()
+    assert "companies.cik = '0000320193'" in sql
+
+
+def test_apply_filters_form_types_uses_in_clause() -> None:
+    base = _base_select(func.count())
+    stmt = _apply_filters(
+        base,
+        as_of_date=None,
+        cik=None,
+        form_types=frozenset({"10-K", "10-Q"}),
+        section_labels=None,
+    )
+
+    sql = _compile(stmt).lower()
+    assert "filings.form in" in sql
+    assert "'10-k'" in sql and "'10-q'" in sql
+
+
+def test_apply_filters_section_labels_uses_in_clause() -> None:
+    base = _base_select(func.count())
+    stmt = _apply_filters(
+        base,
+        as_of_date=None,
+        cik=None,
+        form_types=None,
+        section_labels=frozenset({"item_1a"}),
+    )
+
+    sql = _compile(stmt).lower()
+    assert "filing_chunks.section_label in" in sql
+    assert "'item_1a'" in sql
+
+
+# --- hybrid_search orchestration -------------------------------------------------
+
+
+def _make_result(chunk_id: int, score: float) -> RetrievalResult:
+    return RetrievalResult(
+        chunk_id=chunk_id,
+        filing_document_id=10 + chunk_id,
+        filing_id=100 + chunk_id,
+        cik="0000000001",
+        ticker="TST",
+        company_name="Test Co",
+        form="10-K",
+        filing_date=date(2025, 1, 1),
+        accession_number=f"0000000001-25-{chunk_id:06d}",
+        section_label="preamble",
+        section_title=None,
+        chunk_index=chunk_id,
+        text=f"chunk text {chunk_id}",
+        score=score,
+    )
+
+
+class _StubEmbedder:
+    model_name = "stub"
+    dimension = 2
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0, 0.0] for _ in texts]
+
+
+async def test_hybrid_search_fuses_dense_and_bm25_ranks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Dense returns chunks 1, 2, 3. BM25 returns chunks 3, 2, 4.
+    # Chunk 2 and 3 appear in both; chunk 3 ranks better overall.
+    dense = [
+        _make_result(1, 0.9),
+        _make_result(2, 0.8),
+        _make_result(3, 0.7),
+    ]
+    bm25 = [
+        _make_result(3, 5.0),
+        _make_result(2, 4.0),
+        _make_result(4, 3.0),
+    ]
+
+    async def fake_dense(**_kwargs: Any) -> list[RetrievalResult]:
+        return dense
+
+    async def fake_bm25(**_kwargs: Any) -> list[RetrievalResult]:
+        return bm25
+
+    monkeypatch.setattr(retrieval_service, "dense_search", fake_dense)
+    monkeypatch.setattr(retrieval_service, "bm25_search", fake_bm25)
+
+    results = await hybrid_search(
+        session=None,  # type: ignore[arg-type]
+        embedder=_StubEmbedder(),
+        query="anything",
+        k=10,
+    )
+
+    # Top results should be chunks that appear in both rankings.
+    assert results[0].chunk_id in {2, 3}
+    assert results[1].chunk_id in {2, 3}
+    # Chunks 1 and 4 (in only one ranking) come after.
+    tail_ids = {r.chunk_id for r in results[2:]}
+    assert tail_ids == {1, 4}
+
+
+async def test_hybrid_search_attaches_per_retriever_ranks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dense = [_make_result(1, 0.9), _make_result(2, 0.5)]
+    bm25 = [_make_result(2, 8.0), _make_result(3, 2.0)]
+
+    async def fake_dense(**_kwargs: Any) -> list[RetrievalResult]:
+        return dense
+
+    async def fake_bm25(**_kwargs: Any) -> list[RetrievalResult]:
+        return bm25
+
+    monkeypatch.setattr(retrieval_service, "dense_search", fake_dense)
+    monkeypatch.setattr(retrieval_service, "bm25_search", fake_bm25)
+
+    results = await hybrid_search(
+        session=None,  # type: ignore[arg-type]
+        embedder=_StubEmbedder(),
+        query="anything",
+        k=10,
+    )
+
+    by_id = {r.chunk_id: r for r in results}
+    # Chunk 1 only in dense at rank 1.
+    assert by_id[1].dense_rank == 1
+    assert by_id[1].bm25_rank is None
+    # Chunk 2 in both: dense rank 2, bm25 rank 1.
+    assert by_id[2].dense_rank == 2
+    assert by_id[2].bm25_rank == 1
+    # Chunk 3 only in bm25 at rank 2.
+    assert by_id[3].dense_rank is None
+    assert by_id[3].bm25_rank == 2
+
+
+async def test_hybrid_search_respects_k(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_dense(**_kwargs: Any) -> list[RetrievalResult]:
+        return [_make_result(i, 1.0 / i) for i in range(1, 11)]
+
+    async def fake_bm25(**_kwargs: Any) -> list[RetrievalResult]:
+        return [_make_result(i + 100, 1.0 / i) for i in range(1, 11)]
+
+    monkeypatch.setattr(retrieval_service, "dense_search", fake_dense)
+    monkeypatch.setattr(retrieval_service, "bm25_search", fake_bm25)
+
+    results = await hybrid_search(
+        session=None,  # type: ignore[arg-type]
+        embedder=_StubEmbedder(),
+        query="anything",
+        k=3,
+    )
+
+    assert len(results) == 3
+
+
+async def test_hybrid_search_rejects_non_positive_k() -> None:
+    with pytest.raises(ValueError, match="k must be positive"):
+        await hybrid_search(
+            session=None,  # type: ignore[arg-type]
+            embedder=_StubEmbedder(),
+            query="anything",
+            k=0,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -27,12 +27,20 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
+    { name = "beautifulsoup4" },
     { name = "httpx" },
+    { name = "lxml" },
+    { name = "pgvector" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "redis" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "tenacity" },
+]
+
+[package.optional-dependencies]
+rerank = [
+    { name = "sentence-transformers" },
 ]
 
 [package.dev-dependencies]
@@ -50,13 +58,18 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.14" },
     { name = "asyncpg", specifier = ">=0.29" },
+    { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "httpx", specifier = ">=0.28" },
+    { name = "lxml", specifier = ">=5.3" },
+    { name = "pgvector", specifier = ">=0.3" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "redis", specifier = ">=5.2" },
+    { name = "sentence-transformers", marker = "extra == 'rerank'", specifier = ">=3.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "tenacity", specifier = ">=9.0" },
 ]
+provides-extras = ["rerank"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -67,6 +80,15 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0" },
     { name = "respx", specifier = ">=0.22" },
     { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
@@ -149,6 +171,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -164,6 +199,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -280,6 +327,77 @@ toml = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/94/2748597f47bb1600cd466b20cab4159f1530a3a33fe7f70fee199b3abb9e/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1eba9504ac70667dd48313395fe05157518fd6371b532790e96fbb31bbb5a5e1", size = 6313924, upload-time = "2026-03-11T00:12:39.462Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/92/f899f7bbb5617bb65ec52a6eac1e9a1447a86b916c4194f8a5001b8cde0c/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46d8776a55d6d5da9dd6e9858fba2efcda2abe6743871dee47dd06eb8cb6d955", size = 6320619, upload-time = "2026-03-11T00:12:45.939Z" },
+    { url = "https://files.pythonhosted.org/packages/df/93/eef988860a3ca985f82c4f3174fc0cdd94e07331ba9a92e8e064c260337f/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6629ca2df6f795b784752409bcaedbd22a7a651b74b56a165ebc0c9dcbd504d0", size = 5614610, upload-time = "2026-03-11T00:12:50.337Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/6db3aba46864aee357ab2415135b3fe3da7e9f1fa0221fa2a86a5968099c/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dca0da053d3b4cc4869eff49c61c03f3c5dbaa0bcd712317a358d5b8f3f385d", size = 6149914, upload-time = "2026-03-11T00:12:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/87/87a014f045b77c6de5c8527b0757fe644417b184e5367db977236a141602/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e", size = 5685673, upload-time = "2026-03-11T00:12:56.371Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5e/c0fe77a73aaefd3fff25ffaccaac69c5a63eafdf8b9a4c476626ef0ac703/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4af9f3e1be603fa12d5ad6cfca7844c9d230befa9792b5abdf7dd79979c3626", size = 6191386, upload-time = "2026-03-11T00:12:58.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/58/ed2c3b39c8dd5f96aa7a4abef0d47a73932c7a988e30f5fa428f00ed0da1/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df850a1ff8ce1b3385257b08e47b70e959932f5f432d0a4e46a355962b4e4771", size = 5507469, upload-time = "2026-03-11T00:13:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/0c941b112ceeb21439b05895eace78ca1aa2eaaf695c8521a068fd9b4c00/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8a16384c6494e5485f39314b0b4afb04bee48d49edb16d5d8593fd35bbd231b", size = 6059693, upload-time = "2026-03-11T00:13:06.003Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/d0/c177e29701cf1d3008d7d2b16b5fc626592ce13bd535f8795c5f57187e0e/cuda_pathfinder-1.5.4-py3-none-any.whl", hash = "sha256:9563d3175ce1828531acf4b94e1c1c7d67208c347ca002493e2654878b26f4b7", size = 51657, upload-time = "2026-04-27T22:42:07.712Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -295,6 +413,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
 ]
 
 [[package]]
@@ -364,6 +491,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
+    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
+    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/8fc8996afe5815fa1a6be8e9e5c02f24500f409d599e905800d498a4e14d/hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c", size = 4023495, upload-time = "2026-05-06T06:18:01.94Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/93d84463c00cecb561a7508aa6303e35ee2894294eac14245526924415fe/hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73", size = 3792731, upload-time = "2026-05-06T06:18:00.021Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5a/8ec8e0c863b382d00b3c2e2af6ded6b06371be617144a625903a6d562f4b/hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682", size = 4456738, upload-time = "2026-05-06T06:17:49.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ca/f7effa1a67717da2bcc6b6c28f71c6ca648c77acaec4e2c32f40cbe16d85/hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761", size = 4251622, upload-time = "2026-05-06T06:17:47.096Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f2/19247dba3e231cf77dec59ddfb878f00057635ff773d099c9b59d37812c3/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded", size = 4445667, upload-time = "2026-05-06T06:18:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/64/6f116801a3bcfb6f59f5c251f48cadc47ea54026441c4a385079286a94fa/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702", size = 4664619, upload-time = "2026-05-06T06:18:13.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/069542d37946ed08669b127e1496fa99e78196d71de8d41eda5e9f1b7a58/hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e", size = 3966802, upload-time = "2026-05-06T06:18:28.162Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/91/fc6fdec27b14d04e88c386ac0a0129732b53fa23f7c4a78f4b83a039c567/hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0", size = 3797168, upload-time = "2026-05-06T06:18:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -392,6 +551,26 @@ wheels = [
 ]
 
 [[package]]
+name = "huggingface-hub"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/40/43109e943fd718b0ccd0cd61eb4f1c347df22bf81f5874c6f22adf44bcff/huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2", size = 782365, upload-time = "2026-05-06T14:14:34.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/a5/33b49ba7bea7c41bb37f74ec0f8beea0831e052330196633fe2c77516ea6/huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8", size = 661479, upload-time = "2026-05-06T14:14:32.029Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -416,6 +595,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -492,6 +692,108 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/5d/3bccad330292946f97962df9d5f2d3ae129cce6e212732a781e856b91e07/lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9", size = 8526232, upload-time = "2026-04-18T04:27:40.389Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/adc8826570a112f83bb4ddb3a2ab510bbc2ccd62c1b9fe1f34fae2d90b57/lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50", size = 4595448, upload-time = "2026-04-18T04:27:44.208Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/5a9ec07cbe1d2334a6465f863b949a520d2699a755738986dcd3b6b89e3f/lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5", size = 4923771, upload-time = "2026-04-18T04:32:17.402Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/23/851cfa33b6b38adb628e45ad51fb27105fa34b2b3ba9d1d4aa7a9428dfe0/lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e", size = 5068101, upload-time = "2026-04-18T04:32:21.437Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/38/41bf99c2023c6b79916ba057d83e9db21d642f473cac210201222882d38b/lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512", size = 5002573, upload-time = "2026-04-18T04:32:25.373Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/053aa10bdc39747e1e923ce2d45413075e84f70a136045bb09e5eaca41d3/lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c", size = 5202816, upload-time = "2026-04-18T04:32:29.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/bc710fad8bf04b93baee752c192eaa2210cd3a84f969d0be7830fea55802/lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5", size = 5329999, upload-time = "2026-04-18T04:32:34.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/bf035dedbdf7fab49411aa52e4236f3445e98d38647d85419e6c0d2806b9/lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289", size = 4659643, upload-time = "2026-04-18T04:32:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/22be31f33727a5e4c7b01b0a874503026e50329b259d3587e0b923cf964b/lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a", size = 5265963, upload-time = "2026-04-18T04:32:41.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2b/d44d0e5c79226017f4ab8c87a802ebe4f89f97e6585a8e4166dffcdd7b6e/lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3", size = 5045444, upload-time = "2026-04-18T04:32:44.512Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c3/3f034fec1594c331a6dbf9491238fdcc9d66f68cc529e109ec75b97197e1/lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9", size = 4712703, upload-time = "2026-04-18T04:32:47.16Z" },
+    { url = "https://files.pythonhosted.org/packages/12/16/0b83fccc158218aca75a7aa33e97441df737950734246b9fffa39301603d/lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11", size = 5252745, upload-time = "2026-04-18T04:32:50.427Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ee/12e6c1b39a77666c02eaa77f94a870aaf63c4ac3a497b2d52319448b01c6/lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4", size = 5226822, upload-time = "2026-04-18T04:32:53.437Z" },
+    { url = "https://files.pythonhosted.org/packages/34/20/c7852904858b4723af01d2fc14b5d38ff57cb92f01934a127ebd9a9e51aa/lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3", size = 3594026, upload-time = "2026-04-18T04:27:31.903Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/d60c732b56da5085175c07c74b2df4e6d181b0c9a61e1691474f06ef4b39/lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7", size = 4025114, upload-time = "2026-04-18T04:27:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/df/c84dcc175fd690823436d15b41cb920cd5ba5e14cd8bfb00949d5903b320/lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39", size = 3667742, upload-time = "2026-04-18T04:27:38.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/88/55143966481409b1740a3ac669e611055f49efd68087a5ce41582325db3e/lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842", size = 3930134, upload-time = "2026-04-18T04:32:35.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/97/28b985c2983938d3cb696dd5501423afb90a8c3e869ef5d3c62569282c0f/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c", size = 4210749, upload-time = "2026-04-18T04:36:03.626Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/dfab2b7d58214921935ccea7ce9b3df9b7d46f305d12f0f532ac7cf6b804/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de", size = 4318463, upload-time = "2026-04-18T04:36:06.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a2/4ac7eb32a4d997dd352c32c32399aae27b3f268d440e6f9cfa405b575d2f/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635", size = 4251124, upload-time = "2026-04-18T04:36:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/d6abd850bb4822f9b720cfe36b547a558e694881010ff7d012191e8769c6/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037", size = 4401758, upload-time = "2026-04-18T04:36:11.803Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/3ee09a5b60cb44c4f2fbc1c9015cfd6ff5afc08f991cab295d3024dcbf2d/lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace", size = 3508860, upload-time = "2026-04-18T04:32:48.619Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
@@ -501,6 +803,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -578,6 +892,24 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
@@ -637,12 +969,249 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c6/4218570d8c8ecc9704b5157a3348e486e84ef4be0ed3e38218ab473c83d2/numpy-2.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f983334aea213c99992053ede6168500e5f086ce74fbc4acc3f2b00f5762e9db", size = 16976799, upload-time = "2026-03-29T13:18:15.438Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/92/b4d922c4a5f5dab9ed44e6153908a5c665b71acf183a83b93b690996e39b/numpy-2.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:72944b19f2324114e9dc86a159787333b77874143efcf89a5167ef83cfee8af0", size = 14971552, upload-time = "2026-03-29T13:18:18.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/dc/df98c095978fa6ee7b9a9387d1d58cbb3d232d0e69ad169a4ce784bde4fd/numpy-2.4.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:86b6f55f5a352b48d7fbfd2dbc3d5b780b2d79f4d3c121f33eb6efb22e9a2015", size = 5476566, upload-time = "2026-03-29T13:18:21.532Z" },
+    { url = "https://files.pythonhosted.org/packages/28/34/b3fdcec6e725409223dd27356bdf5a3c2cc2282e428218ecc9cb7acc9763/numpy-2.4.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:ba1f4fc670ed79f876f70082eff4f9583c15fb9a4b89d6188412de4d18ae2f40", size = 6806482, upload-time = "2026-03-29T13:18:23.634Z" },
+    { url = "https://files.pythonhosted.org/packages/68/62/63417c13aa35d57bee1337c67446761dc25ea6543130cf868eace6e8157b/numpy-2.4.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a87ec22c87be071b6bdbd27920b129b94f2fc964358ce38f3822635a3e2e03d", size = 15973376, upload-time = "2026-03-29T13:18:26.677Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c5/9fcb7e0e69cef59cf10c746b84f7d58b08bc66a6b7d459783c5a4f6101a6/numpy-2.4.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df3775294accfdd75f32c74ae39fcba920c9a378a2fc18a12b6820aa8c1fb502", size = 16925137, upload-time = "2026-03-29T13:18:30.14Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/43/80020edacb3f84b9efdd1591120a4296462c23fd8db0dde1666f6ef66f13/numpy-2.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0d4e437e295f18ec29bc79daf55e8a47a9113df44d66f702f02a293d93a2d6dd", size = 17329414, upload-time = "2026-03-29T13:18:33.733Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/06/af0658593b18a5f73532d377188b964f239eb0894e664a6c12f484472f97/numpy-2.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6aa3236c78803afbcb255045fbef97a9e25a1f6c9888357d205ddc42f4d6eba5", size = 18658397, upload-time = "2026-03-29T13:18:37.511Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ce/13a09ed65f5d0ce5c7dd0669250374c6e379910f97af2c08c57b0608eee4/numpy-2.4.4-cp311-cp311-win32.whl", hash = "sha256:30caa73029a225b2d40d9fae193e008e24b2026b7ee1a867b7ee8d96ca1a448e", size = 6239499, upload-time = "2026-03-29T13:18:40.372Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/63/05d193dbb4b5eec1eca73822d80da98b511f8328ad4ae3ca4caf0f4db91d/numpy-2.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:6bbe4eb67390b0a0265a2c25458f6b90a409d5d069f1041e6aff1e27e3d9a79e", size = 12614257, upload-time = "2026-03-29T13:18:42.95Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c5/8168052f080c26fa984c413305012be54741c9d0d74abd7fbeeccae3889f/numpy-2.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:fcfe2045fd2e8f3cb0ce9d4ba6dba6333b8fa05bb8a4939c908cd43322d14c7e", size = 10486775, upload-time = "2026-03-29T13:18:45.835Z" },
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/33/8fae8f964a4f63ed528264ddf25d2b683d0b663e3cba26961eb838a7c1bd/numpy-2.4.4-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:58c8b5929fcb8287cbd6f0a3fae19c6e03a5c48402ae792962ac465224a629a4", size = 16854491, upload-time = "2026-03-29T13:21:38.03Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d0/1aabee441380b981cf8cdda3ae7a46aa827d1b5a8cce84d14598bc94d6d9/numpy-2.4.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:eea7ac5d2dce4189771cedb559c738a71512768210dc4e4753b107a2048b3d0e", size = 14895830, upload-time = "2026-03-29T13:21:41.509Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b8/aafb0d1065416894fccf4df6b49ef22b8db045187949545bced89c034b8e/numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:51fc224f7ca4d92656d5a5eb315f12eb5fe2c97a66249aa7b5f562528a3be38c", size = 5400927, upload-time = "2026-03-29T13:21:44.747Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/77/063baa20b08b431038c7f9ff5435540c7b7265c78cf56012a483019ca72d/numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:28a650663f7314afc3e6ec620f44f333c386aad9f6fc472030865dc0ebb26ee3", size = 6715557, upload-time = "2026-03-29T13:21:47.406Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a8/379542d45a14f149444c5c4c4e7714707239ce9cc1de8c2803958889da14/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19710a9ca9992d7174e9c52f643d4272dcd1558c5f7af7f6f8190f633bd651a7", size = 15804253, upload-time = "2026-03-29T13:21:50.753Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/c8/f0a45426d6d21e7ea3310a15cf90c43a14d9232c31a837702dba437f3373/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b2aec6af35c113b05695ebb5749a787acd63cafc83086a05771d1e1cd1e555f", size = 16753552, upload-time = "2026-03-29T13:21:54.344Z" },
+    { url = "https://files.pythonhosted.org/packages/04/74/f4c001f4714c3ad9ce037e18cf2b9c64871a84951eaa0baf683a9ca9301c/numpy-2.4.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2cf083b324a467e1ab358c105f6cad5ea950f50524668a80c486ff1db24e119", size = 12509075, upload-time = "2026-03-29T13:21:57.644Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.0.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.19.0.56"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.28.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -661,6 +1230,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/6c/6d8b4b03b958c02fa8687ec6063c49d952a189f8c91ebbe51e877dfab8f7/pgvector-0.4.2.tar.gz", hash = "sha256:322cac0c1dc5d41c9ecf782bd9991b7966685dee3a00bc873631391ed949513a", size = 31354, upload-time = "2025-12-05T01:07:17.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/26/6cee8a1ce8c43625ec561aff19df07f9776b7525d9002c86bceb3e0ac970/pgvector-0.4.2-py3-none-any.whl", hash = "sha256:549d45f7a18593783d5eec609ea1684a724ba8405c4cb182a0b2b08aeff04e08", size = 27441, upload-time = "2025-12-05T01:07:16.536Z" },
 ]
 
 [[package]]
@@ -970,6 +1551,110 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
 name = "respx"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -979,6 +1664,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -1004,6 +1702,195 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/92/53ea2181da8ac6bf27170191028aee7251f8f841f8d3edbfdcaf2008fde9/scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da", size = 8595835, upload-time = "2025-12-10T07:07:39.385Z" },
+    { url = "https://files.pythonhosted.org/packages/01/18/d154dc1638803adf987910cdd07097d9c526663a55666a97c124d09fb96a/scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1", size = 8080381, upload-time = "2025-12-10T07:07:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/44/226142fcb7b7101e64fdee5f49dbe6288d4c7af8abf593237b70fca080a4/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b", size = 8799632, upload-time = "2025-12-10T07:07:43.899Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4d/4a67f30778a45d542bbea5db2dbfa1e9e100bf9ba64aefe34215ba9f11f6/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1", size = 9103788, upload-time = "2025-12-10T07:07:45.982Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/45c352094cfa60050bcbb967b1faf246b22e93cb459f2f907b600f2ceda5/scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b", size = 8081706, upload-time = "2025-12-10T07:07:48.111Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/46/5416595bb395757f754feb20c3d776553a386b661658fb21b7c814e89efe/scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961", size = 7688451, upload-time = "2025-12-10T07:07:49.873Z" },
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/68/7f98c221940ce783b492ad6140384daf2e2918cd7175009d6a362c22b9ee/sentence_transformers-5.4.1.tar.gz", hash = "sha256:436bcb1182a0ff42a8fb2b1c43498a70d0a75b688d182f2cd0d1dd115af61ddc", size = 428910, upload-time = "2026-04-14T13:34:59.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/d9/3a9b6f2ccdedc9dc00fe37b2fc58f58f8efbff44565cf4bf39d8568bb13a/sentence_transformers-5.4.1-py3-none-any.whl", hash = "sha256:a6d640fc363849b63affb8e140e9d328feabab86f83d58ac3e16b1c28140b790", size = 571311, upload-time = "2026-04-14T13:34:57.731Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "81.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]
@@ -1065,12 +1952,59 @@ asyncio = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]
@@ -1125,6 +2059,119 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/0d/98b410492609e34a155fa8b121b55c7dca229f39636851c3a9ec20edea21/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7b6a60d48062809f58595509c524b88e6ddec3ebe25833d6462eeab81e5f2ce4", size = 80529712, upload-time = "2026-03-23T18:12:02.608Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/acea680005f098f79fd70c1d9d5ccc0cb4296ec2af539a0450108232fc0c/torch-2.11.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d91aac77f24082809d2c5a93f52a5f085032740a1ebc9252a7b052ef5a4fddc6", size = 419718178, upload-time = "2026-03-23T18:10:46.675Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/8b/d7be22fbec9ffee6cff31a39f8750d4b3a65d349a286cf4aec74c2375662/torch-2.11.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7aa2f9bbc6d4595ba72138026b2074be1233186150e9292865e04b7a63b8c67a", size = 530604548, upload-time = "2026-03-23T18:10:03.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bd/9912d30b68845256aabbb4a40aeefeef3c3b20db5211ccda653544ada4b6/torch-2.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:73e24aaf8f36ab90d95cd1761208b2eb70841c2a9ca1a3f9061b39fc5331b708", size = 114519675, upload-time = "2026-03-23T18:11:52.995Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
+    { url = "https://files.pythonhosted.org/packages/13/16/42e5915ebe4868caa6bac83a8ed59db57f12e9a61b7d749d584776ed53d5/torch-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f99924682ef0aa6a4ab3b1b76f40dc6e273fca09f367d15a524266db100a723f", size = 419731115, upload-time = "2026-03-23T18:11:06.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c9/82638ef24d7877510f83baf821f5619a61b45568ce21c0a87a91576510aa/torch-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0f68f4ac6d95d12e896c3b7a912b5871619542ec54d3649cf48cc1edd4dd2756", size = 530712279, upload-time = "2026-03-23T18:10:31.481Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ff/6756f1c7ee302f6d202120e0f4f05b432b839908f9071157302cedfc5232/torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10", size = 114556047, upload-time = "2026-03-23T18:10:55.931Z" },
+    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d1/8ed2173589cbfe744ed54e5a73efc107c0085ba5777ee93a5f4c1ab90553/torch-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:63a68fa59de8f87acc7e85a5478bb2dddbb3392b7593ec3e78827c793c4b73fd", size = 419732382, upload-time = "2026-03-23T18:08:30.835Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e1/b73f7c575a4b8f87a5928f50a1e35416b5e27295d8be9397d5293e7e8d4c/torch-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cc89b9b173d9adfab59fd227f0ab5e5516d9a52b658ae41d64e59d2e55a418db", size = 530711509, upload-time = "2026-03-23T18:08:47.213Z" },
+    { url = "https://files.pythonhosted.org/packages/66/82/3e3fcdd388fbe54e29fd3f991f36846ff4ac90b0d0181e9c8f7236565f82/torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd", size = 114555842, upload-time = "2026-03-23T18:09:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/6c/56bfb37073e7136e6dd86bfc6af7339946dd684e0ecf2155ac0eee687ae1/torch-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2658f34ce7e2dabf4ec73b45e2ca68aedad7a5be87ea756ad656eaf32bf1e1ea", size = 419732324, upload-time = "2026-03-23T18:09:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/1b666b6d61d3394cca306ea543ed03a64aad0a201b6cd159f1d41010aeb1/torch-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98bb213c3084cfe176302949bdc360074b18a9da7ab59ef2edc9d9f742504778", size = 530596026, upload-time = "2026-03-23T18:09:20.842Z" },
+    { url = "https://files.pythonhosted.org/packages/48/6b/30d1459fa7e4b67e9e3fe1685ca1d8bb4ce7c62ef436c3a615963c6c866c/torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db", size = 114793702, upload-time = "2026-03-23T18:09:47.304Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0d/8603382f61abd0db35841148ddc1ffd607bf3100b11c6e1dab6d2fc44e72/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7", size = 80573442, upload-time = "2026-03-23T18:09:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/86/7cd7c66cb9cec6be330fff36db5bd0eef386d80c031b581ec81be1d4b26c/torch-2.11.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2bb3cc54bd0dea126b0060bb1ec9de0f9c7f7342d93d436646516b0330cd5be7", size = 419749385, upload-time = "2026-03-23T18:07:33.77Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e8/b98ca2d39b2e0e4730c0ee52537e488e7008025bc77ca89552ff91021f7c/torch-2.11.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4dc8b3809469b6c30b411bb8c4cad3828efd26236153d9beb6a3ec500f211a60", size = 530716756, upload-time = "2026-03-23T18:07:50.02Z" },
+    { url = "https://files.pythonhosted.org/packages/78/88/d4a4cda8362f8a30d1ed428564878c3cafb0d87971fbd3947d4c84552095/torch-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:2b4e811728bd0cc58fb2b0948fe939a1ee2bf1422f6025be2fca4c7bd9d79718", size = 114552300, upload-time = "2026-03-23T18:09:05.617Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/46/4419098ed6d801750f26567b478fc185c3432e11e2cad712bc6b4c2ab0d0/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8245477871c3700d4370352ffec94b103cfcb737229445cf9946cddb7b2ca7cd", size = 80959460, upload-time = "2026-03-23T18:09:00.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/66/54a56a4a6ceaffb567231994a9745821d3af922a854ed33b0b3a278e0a99/torch-2.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:ab9a8482f475f9ba20e12db84b0e55e2f58784bdca43a854a6ccd3fd4b9f75e6", size = 419735835, upload-time = "2026-03-23T18:07:18.974Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e7/0b6665f533aa9e337662dc190425abc0af1fe3234088f4454c52393ded61/torch-2.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:563ed3d25542d7e7bbc5b235ccfacfeb97fb470c7fee257eae599adb8005c8a2", size = 530613405, upload-time = "2026-03-23T18:08:07.014Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bf/c8d12a2c86dbfd7f40fb2f56fbf5a505ccf2d9ce131eb559dfc7c51e1a04/torch-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b2a43985ff5ef6ddd923bbcf99943e5f58059805787c5c9a2622bf05ca2965b0", size = 114792991, upload-time = "2026-03-23T18:08:19.216Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/36/390075693b76d4fb4a2bea360fb6080347763bd1f1147c49ed0ed938778c/transformers-5.8.0.tar.gz", hash = "sha256:6cc9a1f0291d16b1c1b735bad775e78ebefff7722701d4e28f98aaaa2bd6fb91", size = 8528141, upload-time = "2026-05-05T16:50:04.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/7b/5621d08b34ac35deb9fa14b58d27d124d21ef125ee1c64bc724ca47dfb63/transformers-5.8.0-py3-none-any.whl", hash = "sha256:e9d2cae6d195a7e1e05164c5ebf26142a7044e4dc4267274f4809204f92827e4", size = 10630279, upload-time = "2026-05-05T16:50:01.026Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2c/96f92f3c60387e14cc45aed49487f3486f89ea27106c1b1376913c62abe4/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651", size = 176081190, upload-time = "2026-01-20T16:16:00.523Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the Phase 2 roadmap bullets. Built incrementally as four slices, all wired end-to-end through `make migrate`, `scripts/ingest_edgar.py`, and `scripts/query.py`.

## Summary

- **Chunking** — `parse_filing_html` (leaf block elements, preserves inline-XBRL spans) → `detect_sections` (Item/Part headings with TOC dedup) → `chunk_filing` (paragraph-aware, overlapping, char-budget). `FilingChunk` ORM + migration `0004`. Idempotent re-chunk via `source_content_hash`.
- **Embeddings** — `Embedder` protocol + `DeterministicEmbedder` (hash-bag, L2-norm, for tests) + `GeminiEmbedder` calling `text-embedding-004` via httpx + tenacity + token-bucket. Migrations `0005` (vector + model + timestamp) and `0006` (widen to 768 to match Gemini). Free-tier defaults (1500 RPM ceiling, transparent slicing at the 100-input batch cap).
- **Retrieval** — `dense_search` (pgvector cosine ANN, HNSW), `bm25_search` (`ts_rank_cd` over a generated `text_tsv` column, GIN), `hybrid_search` fusing both via Reciprocal Rank Fusion. Filters shared across all three: `as_of_date` (no filings dated after — required for honest backtests), `cik`, `form_types`, `section_labels`. Migration `0007`. `scripts/query.py` CLI.
- **Reranking** — `Reranker` protocol + Jaccard `DeterministicReranker` (tests) + `CrossEncoderReranker` wrapping `sentence-transformers` behind the optional `rerank` extra (`uv sync --extra rerank`). `rerank_results` adapts onto `RetrievalResult`. `scripts/query.py --rerank`.

## Try it

\`\`\`bash
make migrate
uv run python scripts/ingest_edgar.py --ticker AAPL MSFT NVDA --embed --limit 5
uv run python scripts/query.py "supply chain risk" --form 10-K --k 5
uv run python scripts/query.py "ai chip demand" --rerank
\`\`\`

Gemini path needs \`GOOGLE_API_KEY\` from https://aistudio.google.com/app/apikey + \`EMBEDDER_BACKEND=gemini\`.

## Test plan

- [x] \`uv run pytest -m "not integration"\` — 123 tests pass
- [x] \`uv run mypy src tests\` — clean (strict)
- [x] \`uv run ruff check src tests scripts\` — clean
- [ ] Apply migrations against the local compose stack and run an end-to-end ingest + query
- [ ] Verify Gemini path with a real \`GOOGLE_API_KEY\` against the actual REST endpoint
- [ ] Verify rerank path with \`uv sync --extra rerank\` and the real cross-encoder model

## Note for review

There are two existing branches with related work — \`feat/phase-2-retrieval\` and \`feat/phase-3-real-models\` — from prior sessions that have not been merged to \`main\`. This branch was built independently and covers overlapping ground (chunking, embeddings, hybrid retrieval) plus the rerank step. Worth comparing before merging if those branches are still candidates.

What this branch is **not** doing yet:
- Integration tests against a live Postgres + pgvector (the SQL-level behavior of `cosine_distance`, `ts_rank_cd`, HNSW/GIN is unverified by the unit suite — flagged in test module docstrings)
- An ADR for the retrieval design

🤖 Generated with [Claude Code](https://claude.com/claude-code)