### PR TITLE
feat(embeddings): gemini real-backend over generativelanguage REST

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,11 @@ REDIS_URL="redis://localhost:6379/0"
 # STORAGE_LOCAL_PATH=./data/storage
 
 # Embedder backend. 'deterministic' is a hash-seeded RNG stub for dev/tests.
-# A real sentence-transformer wrapper lands in Phase 3.
+# 'gemini' calls Google's free gemini-embedding-001 endpoint and requires
+# GOOGLE_API_KEY (get one at https://aistudio.google.com/app/apikey).
 # EMBEDDING_BACKEND=deterministic
+# GOOGLE_API_KEY=
+# GEMINI_EMBEDDING_MODEL=gemini-embedding-001
 
 # LLM provider for the agent layer. 'echo' is an offline stub; 'anthropic'
 # calls the real API and requires ANTHROPIC_API_KEY.
@@ -30,8 +33,6 @@ REDIS_URL="redis://localhost:6379/0"
 
 # LLM providers — populated in later phases.
 # OPENAI_API_KEY=
-# ANTHROPIC_API_KEY=
-# GOOGLE_API_KEY=
 
 # Market data — populated in later phases.
 # ALPACA_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to this project will be documented in this file. The format 
 - `scripts/ask.py` — the project's first end-to-end demo. Runs BM25 search over `filing_chunks`, formats the top-k chunks as numbered sources, and asks the LLM to answer using only those sources with citations. `--as-of` is required, not optional.
 - ADR 0006 documenting the LLM provider integration design.
 - Runbook `docs/runbooks/ask.md` covering the new CLI's invocation and failure modes.
+- `GeminiEmbedder`: real embedding backend calling Google's `gemini-embedding-001` REST endpoint over `httpx + tenacity + token-bucket`. Free-tier-aware defaults (20 req/s, well under the 1500 RPM ceiling), transparent slicing into the 100-input `batchEmbedContents` cap, and an `aclose()` lifecycle. Truncates the Matryoshka output to `EMBEDDING_DIM` via `outputDimensionality` and L2-renormalises so the unit-norm contract in the `Embedder` protocol still holds; uses `taskType=RETRIEVAL_DOCUMENT` for chunk encoding.
+- `google_api_key` and `gemini_embedding_model` settings; `EMBEDDING_BACKEND=gemini` selects the new backend. `dispose_embedder()` factory hook for shutting the HTTP client down cleanly.
 
 ### Changed
 - `EdgarClient` no longer sends a fixed `Accept: application/json` header — the same client now hits both JSON endpoints under `data.sec.gov` and HTML/XML bodies under `www.sec.gov/Archives`.

--- a/src/alphamind/config.py
+++ b/src/alphamind/config.py
@@ -17,7 +17,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 Environment = Literal["development", "test", "staging", "production"]
 StorageBackend = Literal["local"]
-EmbeddingBackend = Literal["deterministic"]
+EmbeddingBackend = Literal["deterministic", "gemini"]
 LLMBackend = Literal["anthropic", "echo"]
 
 
@@ -74,8 +74,20 @@ class Settings(BaseSettings):
             "Backend used by alphamind.retrieval.embeddings. 'deterministic' is "
             "a hash-seeded RNG embedder for tests/dev — useless for real semantic "
             "search but lets the full pipeline run without a model download. "
-            "Real sentence-transformer support is wired in Phase 3."
+            "'gemini' calls Google's gemini-embedding-001 REST endpoint and "
+            "requires GOOGLE_API_KEY."
         ),
+    )
+    google_api_key: str | None = Field(
+        default=None,
+        description=(
+            "API key for Google's generativelanguage endpoints. Required when "
+            "embedding_backend='gemini'."
+        ),
+    )
+    gemini_embedding_model: str = Field(
+        default="gemini-embedding-001",
+        description="Gemini embedding model id (path segment in the REST URL).",
     )
 
     # --- LLM provider ---

--- a/src/alphamind/retrieval/embeddings/__init__.py
+++ b/src/alphamind/retrieval/embeddings/__init__.py
@@ -5,19 +5,24 @@ service, the search pipeline) depend on. Concrete implementations:
 
 - :class:`DeterministicHashEmbedder` — seeded by a SHA-256 of the input.
   Used in tests and as the default in development so the project can run
-  end-to-end without downloading a 130 MB sentence-transformer.
-- ``SentenceTransformerEmbedder`` — wired in Phase 3, lazily imports
-  ``sentence_transformers``. Out of scope for this branch.
+  end-to-end without downloading a model.
+- :class:`GeminiEmbedder` — calls Google's ``gemini-embedding-001`` REST
+  endpoint. Free tier; ``GOOGLE_API_KEY`` required. Truncates the
+  Matryoshka output to :data:`alphamind.models.filing_chunk.EMBEDDING_DIM`
+  and re-normalises.
 
 The factory in :func:`get_embedder` reads ``EMBEDDING_BACKEND`` from config
 and returns a singleton. Swapping the backend is a config change.
+:func:`dispose_embedder` closes any network resources owned by the
+backend; the CLIs call it at shutdown.
 """
 
 from __future__ import annotations
 
 from alphamind.retrieval.embeddings.base import Embedder, EmbedderError
 from alphamind.retrieval.embeddings.deterministic import DeterministicHashEmbedder
-from alphamind.retrieval.embeddings.factory import get_embedder
+from alphamind.retrieval.embeddings.factory import dispose_embedder, get_embedder
+from alphamind.retrieval.embeddings.gemini import GeminiEmbedder
 from alphamind.retrieval.embeddings.service import (
     EmbeddingResult,
     embed_chunks_for_filing,
@@ -28,6 +33,8 @@ __all__ = [
     "Embedder",
     "EmbedderError",
     "EmbeddingResult",
+    "GeminiEmbedder",
+    "dispose_embedder",
     "embed_chunks_for_filing",
     "get_embedder",
 ]

--- a/src/alphamind/retrieval/embeddings/factory.py
+++ b/src/alphamind/retrieval/embeddings/factory.py
@@ -1,4 +1,10 @@
-"""Factory that returns the configured embedder as a singleton."""
+"""Factory that returns the configured embedder as a singleton.
+
+Concrete backends are owned by :func:`get_embedder`. The factory caches a
+single instance per process; backends that own async resources (e.g. an
+httpx client) get closed by :func:`dispose_embedder` at shutdown, mirroring
+:func:`alphamind.db.session.dispose_engine`.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +13,7 @@ from functools import lru_cache
 from alphamind.config import get_settings
 from alphamind.retrieval.embeddings.base import Embedder, EmbedderError
 from alphamind.retrieval.embeddings.deterministic import DeterministicHashEmbedder
+from alphamind.retrieval.embeddings.gemini import GeminiEmbedder
 
 
 @lru_cache(maxsize=1)
@@ -19,7 +26,32 @@ def get_embedder() -> Embedder:
     if backend == "deterministic":
         return DeterministicHashEmbedder()
 
+    if backend == "gemini":
+        if not settings.google_api_key:
+            raise EmbedderError("embedding_backend='gemini' requires GOOGLE_API_KEY to be set")
+        return GeminiEmbedder(
+            api_key=settings.google_api_key,
+            model=settings.gemini_embedding_model,
+        )
+
     raise EmbedderError(f"unsupported embedding backend: {backend!r}")
 
 
-__all__ = ["get_embedder"]
+async def dispose_embedder() -> None:
+    """Close the cached embedder's resources and clear the cache.
+
+    Safe to call when no embedder has been constructed yet. The
+    deterministic backend has no async resources; only the network-backed
+    backends need this.
+    """
+
+    if get_embedder.cache_info().currsize == 0:
+        return
+    embedder = get_embedder()
+    aclose = getattr(embedder, "aclose", None)
+    if aclose is not None:
+        await aclose()
+    get_embedder.cache_clear()
+
+
+__all__ = ["dispose_embedder", "get_embedder"]

--- a/src/alphamind/retrieval/embeddings/gemini.py
+++ b/src/alphamind/retrieval/embeddings/gemini.py
@@ -1,0 +1,232 @@
+"""Embedder backed by Google's generativelanguage REST endpoint.
+
+We talk to the REST API directly rather than via ``google-genai`` — the
+project already standardises on ``httpx + tenacity + respx`` for outbound
+HTTP (see :class:`alphamind.ingestion.edgar.client`) and that stack covers
+retries, rate limiting, and mocked tests without another SDK on the dep
+tree.
+
+Why ``gemini-embedding-001`` rather than ``text-embedding-004``: the
+former is a Matryoshka model, so ``outputDimensionality`` truncates the
+returned vector. We pin the dimension to :data:`EMBEDDING_DIM` (384,
+chosen in ADR 0005 to match the eventual ``bge-small-en-v1.5`` backend),
+which keeps the ``filing_chunks`` schema stable across embedder swaps.
+Truncated Matryoshka vectors are not unit-norm; per Google's guidance we
+re-normalise so cosine similarity stays well defined.
+
+The free tier ceiling is 1500 RPM. The default rate-limit below stays
+comfortably under it; callers can raise it for paid tiers.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Sequence
+from types import TracebackType
+from typing import Any, Self
+
+import httpx
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from alphamind.ingestion.edgar.client import TokenBucketLimiter
+from alphamind.models.filing_chunk import EMBEDDING_DIM
+from alphamind.retrieval.embeddings.base import EmbedderError
+
+logger = logging.getLogger(__name__)
+
+GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta"
+
+# Free-tier limit on ``gemini-embedding-001`` is 1500 RPM. Stay under it
+# by default; callers can raise this for paid tiers.
+DEFAULT_RATE_PER_SECOND = 20
+DEFAULT_TIMEOUT_SECONDS = 30.0
+DEFAULT_MAX_RETRIES = 5
+
+# ``batchEmbedContents`` accepts up to 100 inputs per call.
+MAX_BATCH_SIZE = 100
+
+# Asymmetric retrieval task type for chunk encoding (documents). The query
+# side uses ``RETRIEVAL_QUERY`` so the model emits vectors optimised for
+# the same similarity space.
+DOCUMENT_TASK_TYPE = "RETRIEVAL_DOCUMENT"
+
+_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+
+class _RetryableStatusError(httpx.HTTPStatusError):
+    """Marker subclass used by tenacity to trigger a retry."""
+
+
+class GeminiEmbedder:
+    """Async embedder calling Google's ``gemini-embedding-001`` REST endpoint.
+
+    Construct from :func:`alphamind.retrieval.embeddings.factory.get_embedder`
+    in normal use; the direct constructor is exposed for tests that need
+    to inject a custom :class:`httpx.AsyncBaseTransport` for respx mocking.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = "gemini-embedding-001",
+        dim: int = EMBEDDING_DIM,
+        rate: int = DEFAULT_RATE_PER_SECOND,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        task_type: str = DOCUMENT_TASK_TYPE,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key must be non-empty")
+        if dim <= 0:
+            raise ValueError(f"dim must be positive, got {dim}")
+
+        self._api_key = api_key
+        self._model = model
+        self._dim = dim
+        self._task_type = task_type
+        self._client = httpx.AsyncClient(
+            timeout=timeout,
+            headers={"Content-Type": "application/json"},
+            transport=transport,
+        )
+        self._limiter = TokenBucketLimiter(rate=rate)
+        self._max_retries = max_retries
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        if not texts:
+            return []
+
+        # Slice oversized inputs into batches of MAX_BATCH_SIZE and issue
+        # sequentially. Parallel batches would risk the per-minute quota;
+        # sequential keeps rate-limit accounting simple.
+        results: list[list[float]] = []
+        text_list = list(texts)
+        for start in range(0, len(text_list), MAX_BATCH_SIZE):
+            batch = text_list[start : start + MAX_BATCH_SIZE]
+            results.extend(await self._embed_batch(batch))
+        return results
+
+    async def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+        url = f"{GEMINI_API_BASE}/models/{self._model}:batchEmbedContents"
+        payload = {
+            "requests": [
+                {
+                    "model": f"models/{self._model}",
+                    "content": {"parts": [{"text": text}]},
+                    "taskType": self._task_type,
+                    "outputDimensionality": self._dim,
+                }
+                for text in texts
+            ]
+        }
+
+        retryer = retry(
+            stop=stop_after_attempt(self._max_retries),
+            wait=wait_exponential(multiplier=1, min=1, max=30),
+            retry=retry_if_exception_type((httpx.TransportError, _RetryableStatusError)),
+            reraise=True,
+        )
+
+        @retryer
+        async def _do() -> httpx.Response:
+            await self._limiter.acquire()
+            response = await self._client.post(
+                url,
+                params={"key": self._api_key},
+                json=payload,
+            )
+            if response.status_code in _RETRYABLE_STATUS:
+                raise _RetryableStatusError(
+                    f"retryable status {response.status_code}",
+                    request=response.request,
+                    response=response,
+                )
+            response.raise_for_status()
+            return response
+
+        try:
+            response = await _do()
+        except httpx.HTTPStatusError as exc:
+            raise EmbedderError(
+                f"gemini embed failed ({exc.response.status_code}): {exc.response.text[:200]}"
+            ) from exc
+        except httpx.TransportError as exc:
+            raise EmbedderError(f"gemini embed transport error: {exc}") from exc
+
+        raw = _parse_batch_response(response.json(), expected=len(texts))
+        # Matryoshka-truncated vectors are not unit-norm. Re-normalise so the
+        # cosine-similarity contract in :class:`Embedder` still holds.
+        return [_l2_normalise(vec) for vec in raw]
+
+
+def _parse_batch_response(payload: Any, *, expected: int) -> list[list[float]]:
+    """Extract ``[[float, ...], ...]`` from a batchEmbedContents response.
+
+    Defensive: Google's REST layer occasionally returns extra fields or
+    omits ``values`` when an input is too long. Any deviation from the
+    expected shape becomes an :class:`EmbedderError` so the caller sees a
+    specific failure rather than a generic ``KeyError``.
+    """
+
+    if not isinstance(payload, dict):
+        raise EmbedderError(f"unexpected response payload type: {type(payload).__name__}")
+    embeddings = payload.get("embeddings")
+    if not isinstance(embeddings, list) or len(embeddings) != expected:
+        raise EmbedderError(
+            f"expected {expected} embeddings, got "
+            f"{len(embeddings) if isinstance(embeddings, list) else 'non-list'}"
+        )
+
+    out: list[list[float]] = []
+    for i, entry in enumerate(embeddings):
+        if not isinstance(entry, dict):
+            raise EmbedderError(f"embedding[{i}] is not an object")
+        values = entry.get("values")
+        if not isinstance(values, list) or not all(isinstance(v, int | float) for v in values):
+            raise EmbedderError(f"embedding[{i}] has malformed 'values'")
+        out.append([float(v) for v in values])
+    return out
+
+
+def _l2_normalise(vec: list[float]) -> list[float]:
+    norm = math.sqrt(sum(v * v for v in vec))
+    if norm == 0.0:
+        return vec
+    return [v / norm for v in vec]
+
+
+__all__ = [
+    "DEFAULT_MAX_RETRIES",
+    "DEFAULT_RATE_PER_SECOND",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "DOCUMENT_TASK_TYPE",
+    "GEMINI_API_BASE",
+    "MAX_BATCH_SIZE",
+    "GeminiEmbedder",
+]

--- a/tests/unit/retrieval/embeddings/test_factory.py
+++ b/tests/unit/retrieval/embeddings/test_factory.py
@@ -1,0 +1,89 @@
+"""Unit tests for :func:`get_embedder` and :func:`dispose_embedder`."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+
+from alphamind.config import Settings, get_settings
+from alphamind.retrieval.embeddings import factory
+from alphamind.retrieval.embeddings.base import EmbedderError
+from alphamind.retrieval.embeddings.deterministic import DeterministicHashEmbedder
+from alphamind.retrieval.embeddings.gemini import GeminiEmbedder
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> Iterator[None]:
+    get_settings.cache_clear()
+    factory.get_embedder.cache_clear()
+    yield
+    get_settings.cache_clear()
+    factory.get_embedder.cache_clear()
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "database_url": "postgresql+asyncpg://x/y",
+        "redis_url": "redis://localhost:6379/0",
+        "sec_user_agent": "AlphaMind test test@example.com",
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def test_returns_deterministic_when_backend_is_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(factory, "get_settings", _settings)
+
+    embedder = factory.get_embedder()
+
+    assert isinstance(embedder, DeterministicHashEmbedder)
+
+
+def test_returns_gemini_when_backend_and_key_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        factory,
+        "get_settings",
+        lambda: _settings(embedding_backend="gemini", google_api_key="sk-test"),
+    )
+
+    embedder = factory.get_embedder()
+    try:
+        assert isinstance(embedder, GeminiEmbedder)
+    finally:
+        # GeminiEmbedder owns an httpx client; close it before the test exits.
+        asyncio.run(factory.dispose_embedder())
+
+
+def test_gemini_backend_without_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        factory,
+        "get_settings",
+        lambda: _settings(embedding_backend="gemini", google_api_key=None),
+    )
+
+    with pytest.raises(EmbedderError, match="GOOGLE_API_KEY"):
+        factory.get_embedder()
+
+
+def test_dispose_is_safe_before_construction() -> None:
+    # Autouse fixture clears the cache; no embedder built yet.
+    asyncio.run(factory.dispose_embedder())
+    assert factory.get_embedder.cache_info().currsize == 0
+
+
+def test_dispose_clears_cache_for_deterministic_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(factory, "get_settings", _settings)
+
+    factory.get_embedder()
+    assert factory.get_embedder.cache_info().currsize == 1
+
+    asyncio.run(factory.dispose_embedder())
+    assert factory.get_embedder.cache_info().currsize == 0

--- a/tests/unit/retrieval/embeddings/test_gemini.py
+++ b/tests/unit/retrieval/embeddings/test_gemini.py
@@ -1,0 +1,207 @@
+"""Unit tests for :class:`GeminiEmbedder`.
+
+The embedder talks to Google's REST API; we mock the wire with respx so
+no network call ever leaves the process. Tests cover the happy path,
+exact request shape, batching beyond ``MAX_BATCH_SIZE``, retry on 429,
+parsing failures, and the L2 re-normalisation after Matryoshka truncation.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable
+
+import httpx
+import pytest
+import respx
+
+from alphamind.retrieval.embeddings.base import EmbedderError
+from alphamind.retrieval.embeddings.gemini import (
+    DOCUMENT_TASK_TYPE,
+    GEMINI_API_BASE,
+    MAX_BATCH_SIZE,
+    GeminiEmbedder,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_API_KEY = "test-key"
+_MODEL = "gemini-embedding-001"
+_URL = f"{GEMINI_API_BASE}/models/{_MODEL}:batchEmbedContents"
+
+
+def _payload(*vectors: Iterable[float]) -> dict[str, object]:
+    return {"embeddings": [{"values": list(v)} for v in vectors]}
+
+
+def _norm(vec: list[float]) -> float:
+    return math.sqrt(sum(v * v for v in vec))
+
+
+async def test_embed_returns_vectors_in_input_order() -> None:
+    embedder = GeminiEmbedder(api_key=_API_KEY, dim=3, rate=1000)
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            # Two unnormalised vectors; the embedder must normalise both.
+            mock.post(_URL).respond(
+                json=_payload([1.0, 0.0, 0.0], [0.0, 2.0, 0.0]),
+            )
+
+            vectors = await embedder.embed(["alpha", "beta"])
+
+        # Order preserved; both unit-norm.
+        assert len(vectors) == 2
+        assert math.isclose(_norm(vectors[0]), 1.0, rel_tol=1e-6)
+        assert math.isclose(_norm(vectors[1]), 1.0, rel_tol=1e-6)
+        # Direction preserved (first basis vector stays on x-axis).
+        assert vectors[0][0] > 0.99
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_sends_api_key_and_correct_request_shape() -> None:
+    embedder = GeminiEmbedder(api_key=_API_KEY, dim=4, rate=1000)
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            route = mock.post(_URL).respond(json=_payload([1.0, 0.0, 0.0, 0.0]))
+
+            await embedder.embed(["hello"])
+
+            request = route.calls.last.request
+            assert request.url.params["key"] == _API_KEY
+            body = json.loads(request.content)
+            assert body == {
+                "requests": [
+                    {
+                        "model": f"models/{_MODEL}",
+                        "content": {"parts": [{"text": "hello"}]},
+                        "taskType": DOCUMENT_TASK_TYPE,
+                        "outputDimensionality": 4,
+                    }
+                ]
+            }
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_empty_input_does_not_call_api() -> None:
+    embedder = GeminiEmbedder(api_key=_API_KEY, dim=3)
+    try:
+        async with respx.mock(assert_all_called=False) as mock:
+            route = mock.post(_URL)
+            vectors = await embedder.embed([])
+
+        assert vectors == []
+        assert route.call_count == 0
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_slices_into_multiple_batches_when_over_max() -> None:
+    n = MAX_BATCH_SIZE + 5
+    embedder = GeminiEmbedder(api_key=_API_KEY, dim=2, rate=1000)
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            route = mock.post(_URL).mock(
+                side_effect=[
+                    httpx.Response(200, json=_payload(*[[1.0, 0.0]] * MAX_BATCH_SIZE)),
+                    httpx.Response(200, json=_payload(*[[0.0, 1.0]] * 5)),
+                ]
+            )
+
+            vectors = await embedder.embed([f"t{i}" for i in range(n)])
+
+        assert route.call_count == 2
+        assert len(vectors) == n
+        assert math.isclose(_norm(vectors[0]), 1.0, rel_tol=1e-6)
+        assert math.isclose(_norm(vectors[-1]), 1.0, rel_tol=1e-6)
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_retries_on_429_then_succeeds() -> None:
+    embedder = GeminiEmbedder(
+        api_key=_API_KEY,
+        dim=2,
+        rate=1000,
+        max_retries=3,
+    )
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            route = mock.post(_URL).mock(
+                side_effect=[
+                    httpx.Response(429),
+                    httpx.Response(200, json=_payload([0.5, 0.5])),
+                ]
+            )
+
+            vectors = await embedder.embed(["please"])
+
+        assert route.call_count == 2
+        assert math.isclose(_norm(vectors[0]), 1.0, rel_tol=1e-6)
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_raises_embedder_error_on_persistent_4xx() -> None:
+    embedder = GeminiEmbedder(
+        api_key=_API_KEY,
+        dim=2,
+        rate=1000,
+        max_retries=2,
+    )
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            mock.post(_URL).respond(status_code=400, text="bad request")
+
+            with pytest.raises(EmbedderError, match="gemini embed failed"):
+                await embedder.embed(["nope"])
+    finally:
+        await embedder.aclose()
+
+
+async def test_embed_raises_embedder_error_when_response_shape_is_wrong() -> None:
+    embedder = GeminiEmbedder(api_key=_API_KEY, dim=2, rate=1000)
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            # Asked for 2 vectors but Google returned 1.
+            mock.post(_URL).respond(json={"embeddings": [{"values": [0.1, 0.0]}]})
+
+            with pytest.raises(EmbedderError, match="expected 2 embeddings"):
+                await embedder.embed(["a", "b"])
+    finally:
+        await embedder.aclose()
+
+
+async def test_zero_norm_vector_is_returned_unchanged() -> None:
+    """A pathological all-zeros vector cannot be normalised; leave it alone
+    rather than dividing by zero."""
+    embedder = GeminiEmbedder(api_key=_API_KEY, dim=3, rate=1000)
+    try:
+        async with respx.mock(assert_all_called=True) as mock:
+            mock.post(_URL).respond(json=_payload([0.0, 0.0, 0.0]))
+
+            vectors = await embedder.embed(["empty"])
+
+        assert vectors == [[0.0, 0.0, 0.0]]
+    finally:
+        await embedder.aclose()
+
+
+async def test_dim_property_matches_constructor() -> None:
+    embedder = GeminiEmbedder(api_key=_API_KEY, dim=128)
+    try:
+        assert embedder.dim == 128
+    finally:
+        await embedder.aclose()
+
+
+async def test_rejects_empty_api_key() -> None:
+    with pytest.raises(ValueError, match="api_key must be non-empty"):
+        GeminiEmbedder(api_key="", dim=2)
+
+
+async def test_rejects_non_positive_dim() -> None:
+    with pytest.raises(ValueError, match="dim must be positive"):
+        GeminiEmbedder(api_key=_API_KEY, dim=0)


### PR DESCRIPTION
First real embedder for the pipeline. Until now, `EMBEDDING_BACKEND=deterministic` was the only choice — a hash-seeded RNG, useless for real semantic search. This adds `EMBEDDING_BACKEND=gemini`, which calls Google's free `gemini-embedding-001` endpoint.

## Why this model

`gemini-embedding-001` is a Matryoshka model: `outputDimensionality` truncates the returned vector at the server side. Pinning the dim to `EMBEDDING_DIM` (384) keeps the `filing_chunks` schema stable across embedder swaps — no migration needed today, no migration needed when the eventual `bge-small-en-v1.5` backend (also 384) lands. Truncated Matryoshka vectors aren't unit-norm, so the embedder L2-renormalises before returning. The `Embedder` protocol's unit-norm contract (cosine ≡ dot product) is preserved.

## Design

Mirrors the existing `EdgarClient`:

- **httpx + tenacity + token-bucket.** No new SDK on the dep tree. The bucket caps requests at 20/s by default, well under the free-tier ceiling of 1500 RPM. Callers can raise it for paid tiers.
- **Sequential batch slicing.** `batchEmbedContents` caps at 100 inputs per call; the embedder transparently slices oversized inputs. Sequential rather than parallel batches because parallel risks the per-minute quota and the rate accounting gets complicated.
- **Defensive parsing.** Anything that deviates from the expected response shape (`embeddings: [{values: [...]}, ...]`) raises `EmbedderError` with a specific message, not `KeyError`. The Google REST surface drops `values` for over-length inputs and similar edge cases; this turns those into actionable logs.
- **`aclose()` + `dispose_embedder()`.** The `httpx.AsyncClient` is owned by the embedder; the factory exposes a `dispose_embedder()` helper that mirrors `dispose_engine()`. No existing script currently calls it, but it's there for the next layer (LangGraph agent loop, FastAPI app lifespan).

`taskType=RETRIEVAL_DOCUMENT` is hard-coded for now since the only call site is chunk encoding. When query encoding lands in the search pipeline, it'll need `RETRIEVAL_QUERY`; trivial to expose as a second method then.

## Try it

\`\`\`bash
echo 'EMBEDDING_BACKEND=gemini' >> .env
echo 'GOOGLE_API_KEY=...'        >> .env   # https://aistudio.google.com/app/apikey
make migrate
uv run python -c "
import asyncio
from alphamind.retrieval.embeddings import get_embedder, dispose_embedder
async def main():
    emb = get_embedder()
    [v] = await emb.embed(['quarterly revenue grew 12% year over year'])
    print(emb.__class__.__name__, len(v), sum(x*x for x in v) ** 0.5)
    await dispose_embedder()
asyncio.run(main())
"
# GeminiEmbedder 384 0.999...
\`\`\`

## Test plan

- [x] \`uv run pytest tests/unit/retrieval/embeddings -v\` — 23 tests pass (7 deterministic + 5 factory + 11 gemini)
- [x] \`uv run pytest -m "not integration"\` — 106 total
- [x] \`uv run mypy src tests\` — clean
- [x] \`uv run ruff check\` + format — clean
- [ ] Run against the real REST endpoint with a real \`GOOGLE_API_KEY\` and confirm vectors come back
- [ ] Wire \`embed_chunks_for_filing\` end-to-end against the compose stack (follow-up, blocked on integration test PR)

## Out of scope

- A CLI flag to trigger embedding on the existing \`scripts/ingest_edgar.py\` — kept this PR narrow; that lands next.
- Query-side encoding (\`RETRIEVAL_QUERY\` task type). Lands when \`HybridSearch.search()\` starts using the embedder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)