### PR TITLE
feat(agents): sentiment, risk, and a technical no-data stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,14 @@ All notable changes to this project will be documented in this file. The format 
 - `scripts/research.py` — first agentic end-to-end demo of the project. Runs the LangGraph DAG against ingested filings with the same `--as-of` discipline as `ask.py`.
 - ADR 0007 documenting the agent-graph design (LangGraph, typed state, scaffolding, the renumber-before-LLM contract, LLM-judge critic, graph-wide fallback policy).
 - Runbook `docs/runbooks/research.md` covering invocation, expected output, and failure modes.
+- `RiskSpecialist` — Item 1A risk-factor / legal-proceedings analyst. Query augmentation pulls retrieval toward risk-shaped passages without requiring section / form filters.
+- `SentimentSpecialist` — qualitative tone analyst working from MD&A and 8-K narrative. The system prompt is explicit that the stronger signal (earnings transcripts) is not yet ingested, so the agent stays honest about what it can and cannot infer.
+- `TechnicalSpecialist` — registered no-data stub. Returns an empty `SpecialistReport` without retrieval or LLM cost until the market-data adapter exists. Same constructor signature as the others, so graph wiring is uniform.
+- All four specialists registered in `alphamind.agents.graph._default_specialists`. The router can fan out to any subset; the synthesizer treats empty reports the same as full ones.
+- Shared test fixtures in `tests/unit/agents/specialists/conftest.py` (`FakeSearch`, `FakeSession`, `FakeChunk`, helpers) so per-specialist test files focus on their domain-specific surface.
 
 ### Changed
 - `EdgarClient` no longer sends a fixed `Accept: application/json` header — the same client now hits both JSON endpoints under `data.sec.gov` and HTML/XML bodies under `www.sec.gov/Archives`.
-- README roadmap: Phase 2 is now complete (chunker, embeddings, hybrid retrieval, cross-encoder rerank). Phase 3 is in progress — LLM provider integration shipped, real sentence-transformer embedder + cross-encoder rerank shipped, and the LangGraph skeleton + fundamentals specialist + synthesizer + critic now ship in this slice. Remaining specialists (sentiment, technical, risk) land in follow-up PRs.
+- README roadmap: Phase 2 is now complete (chunker, embeddings, hybrid retrieval, cross-encoder rerank). Phase 3 is now complete on the agent-team axis — router, all four specialists (fundamentals, sentiment, risk, and a technical stub), synthesizer, and critic are registered with the graph. Remaining Phase 3 work that doesn't block a research run: streaming, tool use, and cost aggregation (called out as deferred in ADR 0006 and 0007); the market-data adapter that lets the technical specialist drop its stub.
 
 [Unreleased]: https://github.com/Nishchal45/alphamind/compare/HEAD...HEAD

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ LLM_BACKEND=anthropic ANTHROPIC_API_KEY=sk-ant-... \
     --as-of 2024-12-31
 ```
 
-The graph is wired with the fundamentals specialist in this slice;
-sentiment / technical / risk land in follow-up PRs and slot in via the
-shared `SpecialistBase`. Design rationale in [`docs/adr/0007-agent-graph-design.md`](docs/adr/0007-agent-graph-design.md);
+The graph registers all four specialists (fundamentals, sentiment, risk,
+and a no-data technical stub). The router decides which subset runs for
+a given question. Design rationale in [`docs/adr/0007-agent-graph-design.md`](docs/adr/0007-agent-graph-design.md);
 operational details in [`docs/runbooks/research.md`](docs/runbooks/research.md).
 
 Example output:
@@ -117,7 +117,7 @@ CIK          TICKER     SEEN  WRITTEN  NAME
 
 - [x] Phase 1 — repo scaffolding, Postgres + pgvector, SEC EDGAR metadata ingestion
 - [x] Phase 2 — filing-body ingestion, finance-aware chunking, embeddings, hybrid retrieval (BM25 + pgvector + RRF + cross-encoder rerank) with a hard time-horizon filter at every stage
-- [ ] Phase 3 — LLM provider integration (Anthropic adapter shipped), real sentence-transformer embedder + cross-encoder rerank (shipped), LangGraph agent team (router + fundamentals specialist + synthesizer + critic shipped; remaining specialists in follow-ups)
+- [x] Phase 3 — LLM provider integration (Anthropic), real sentence-transformer embedder + cross-encoder rerank, LangGraph agent team (router, fundamentals / sentiment / risk specialists + a registered no-data technical stub, synthesizer, critic). Streaming, tool use, cost aggregation, and the market-data adapter that activates the technical specialist land later.
 - [ ] Phase 4 — fine-tuned SLM on financial text (LoRA / QLoRA)
 - [ ] Phase 5 — FastAPI serving layer with streaming, caching, cost routing
 - [ ] Phase 6 — backtest harness, evaluation set, public result dashboard

--- a/docs/adr/0007-agent-graph-design.md
+++ b/docs/adr/0007-agent-graph-design.md
@@ -106,6 +106,35 @@ Hard filters land in the follow-up that also adds the remaining
 specialists, when we have enough cross-specialist usage to choose
 filter shapes from data instead of guessing.
 
+#### Technical specialist as a no-data stub
+
+Three specialists land in the follow-up — ``RiskSpecialist``,
+``SentimentSpecialist``, and ``TechnicalSpecialist`` — but the
+technical agent has no usable data today. Price action, momentum,
+volatility, and volume signals all require OHLCV bars and corporate
+actions; the architecture map calls out a market-data adapter, but
+ingestion currently covers EDGAR only.
+
+The pragmatic options were:
+
+1. **Skip technical entirely** until the adapter exists. Cleanest, but
+   reshuffles ``ALL_SPECIALISTS`` and the router prompt when the
+   adapter lands.
+2. **Pretend by querying the filing corpus** with technical-flavoured
+   augmentation. This actively returns forward-looking-statement
+   boilerplate and hallucinates "technical" signals out of legal
+   disclaimers. Worse than nothing.
+3. **Register as a stub.** Specialist exists, satisfies the
+   ``SpecialistBase`` constructor signature, returns an empty
+   ``SpecialistReport`` with an honest "no-data" reason. No LLM call,
+   no retrieval, no cost. The router can still route to it; the
+   synthesizer already handles empty reports.
+
+(3) is what ships. The override is one method on the subclass —
+``async def _run(...)`` returns immediately. When the market-data
+adapter exists, the override goes away and the class falls through to
+the standard pipeline.
+
 ### Router: structured JSON, not tool use
 
 The router returns ``{"specialists": [...], "rationale": "..."}``
@@ -174,7 +203,7 @@ the caller, not in the model.
 ## Consequences
 
 - ``scripts/research.py`` is the first agentic end-to-end demo of the
-  project: router → fundamentals → synthesizer → critic, every call
+  project: router → specialists → synthesizer → critic, every call
   going through the :class:`LLMClient` protocol. With
   ``LLM_BACKEND=anthropic`` and a key set, it runs against real
   models; with the defaults it runs entirely offline with stubbed
@@ -182,10 +211,12 @@ the caller, not in the model.
 - ``scripts/ask.py`` keeps working unchanged. Two scripts, two
   workflows: ``ask.py`` is the flat BM25 + LLM smoke test; ``research.py``
   is the agentic pipeline. The boundary is explicit.
-- The remaining three specialists are ~30-line subclasses of
-  :class:`SpecialistBase`. The next PR can also lift query
-  augmentation into section / form filters once we know what filter
-  shapes the specialists actually want.
+- All four specialists are registered. Fundamentals, sentiment, and
+  risk each ship ~30 lines on top of :class:`SpecialistBase`;
+  technical ships as a stub and activates when the market-data
+  adapter lands. Lifting query augmentation into section / form
+  filters lands when cross-specialist usage suggests the right
+  filter shapes.
 - Tool use, streaming, and cost aggregation are still on the
   follow-up list. The graph runs without them today; they fold in
   cleanly when the protocol grows.

--- a/docs/runbooks/research.md
+++ b/docs/runbooks/research.md
@@ -21,9 +21,22 @@ question + as-of date
   → stdout: router decision, per-specialist counts, thesis, sources, critic notes
 ```
 
-Only the fundamentals specialist ships in this slice. The graph
-infrastructure is set up so the remaining specialists (sentiment,
-technical, risk) drop in as 30-line subclasses of `SpecialistBase`.
+All four specialists are registered with the graph:
+
+- **fundamentals** — revenue, margins, segments, guidance. Augmentation
+  pulls retrieval toward MD&A / financial-statement language.
+- **sentiment** — qualitative tone, hedging, outlook language. Works
+  from MD&A and 8-K narrative. Earnings-transcript ingestion isn't
+  built yet, which is the strongest sentiment signal; the system
+  prompt is explicit about that limitation.
+- **risk** — Item 1A risk factors, legal proceedings, concentration
+  risks. Augmentation targets risk-shaped passages.
+- **technical** — no-data stub. The market-data adapter for OHLCV
+  bars and corporate actions isn't built yet, and pretending to do
+  technical analysis from 10-K boilerplate is actively misleading.
+  This specialist is registered (so the router can route to it) but
+  returns an empty report without calling the LLM. Drops the stub
+  when the adapter lands.
 
 ## Prerequisites
 
@@ -106,8 +119,9 @@ no unsupported claims flagged.
 
 | Symptom | Likely cause | Action |
 | --- | --- | --- |
-| `specialists produced 0 report(s)` | Router picked specialists that aren't implemented yet (only `fundamentals` ships in this slice) | Wait for the next agent-team PR, or ask a question the router routes to fundamentals |
-| `(fundamentals specialist produced no findings: retrieval returned no candidates)` | No chunks matched even after query augmentation | Confirm chunks exist for the ticker; widen `--as-of` |
+| `specialists produced 0 report(s)` | Router skipped to synthesizer (rare; only happens when the router picks a specialist name not in the registry) | Check the router rationale in the printed output |
+| `(technical specialist produced no findings: market-data adapter is not built yet ...)` | Expected — the technical specialist is a stub | Either ignore (the router likely shouldn't have picked it) or treat as a TODO for the market-data adapter |
+| `(<specialist> specialist produced no findings: retrieval returned no candidates)` | No chunks matched even after query augmentation | Confirm chunks exist for the ticker; widen `--as-of` |
 | `(fundamentals specialist produced no findings: could not parse specialist response: ...)` | LLM emitted non-JSON or wrong-shape JSON | Re-run; if the model is consistently bad at JSON, try a stronger `LLM_MODEL` |
 | Critic flags everything as unsupported | LLM-judge over-strictness, or specialist hallucinated citations | Manually verify against the source list; consider tightening the specialist system prompt |
 | `synthesizer fallback: ...` printed | Synthesizer's response didn't parse; thesis comes back with the failure in its answer field | Re-run; check the LLM_MODEL is configured to a model that handles structured output reliably |

--- a/src/alphamind/agents/graph.py
+++ b/src/alphamind/agents/graph.py
@@ -1,16 +1,17 @@
 """LangGraph DAG wiring + factory.
 
 ```
-START -> router -> [fundamentals, ...other specialists] -> synthesizer -> critic -> END
+START -> router -> [selected specialists] -> synthesizer -> critic -> END
 ```
 
 The router decides which specialists run; specialists that aren't
 selected are short-circuited via a conditional edge so we don't pay the
 LLM cost on agents whose output the synthesizer will ignore anyway.
 
-Only :class:`FundamentalsSpecialist` is implemented in this slice. The
-graph is built dynamically from a ``specialists`` mapping so the next
-PR can register sentiment/technical/risk without touching this file.
+All four specialists from the architecture map are registered:
+fundamentals, sentiment, risk, and technical. The technical specialist
+is a no-data stub until the market-data adapter exists; see its
+class docstring for the rationale.
 """
 
 from __future__ import annotations
@@ -23,7 +24,12 @@ from langgraph.graph import END, START, StateGraph
 
 from alphamind.agents.critic import CriticNode
 from alphamind.agents.router import RouterNode
-from alphamind.agents.specialists import FundamentalsSpecialist
+from alphamind.agents.specialists import (
+    FundamentalsSpecialist,
+    RiskSpecialist,
+    SentimentSpecialist,
+    TechnicalSpecialist,
+)
 from alphamind.agents.specialists.base import SpecialistBase
 from alphamind.agents.state import AgentState, GraphInput, SpecialistName
 from alphamind.agents.synthesizer import SynthesizerNode
@@ -41,14 +47,16 @@ def _default_specialists(
     llm: LLMClient,
     search: HybridSearch,
 ) -> dict[SpecialistName, SpecialistBase]:
-    """Return the specialists shipped in this slice.
+    """Return the specialists registered with the graph by default.
 
-    Add other specialists here as they land. The keys must match
-    :data:`alphamind.agents.state.ALL_SPECIALISTS`.
+    Keys must match :data:`alphamind.agents.state.ALL_SPECIALISTS`.
     """
 
     return {
         "fundamentals": FundamentalsSpecialist(llm=llm, search=search),
+        "sentiment": SentimentSpecialist(llm=llm, search=search),
+        "risk": RiskSpecialist(llm=llm, search=search),
+        "technical": TechnicalSpecialist(llm=llm, search=search),
     }
 
 

--- a/src/alphamind/agents/specialists/__init__.py
+++ b/src/alphamind/agents/specialists/__init__.py
@@ -10,9 +10,16 @@ Each specialist is a LangGraph node that:
 3. Parses the response into a :class:`SpecialistReport` with cited
    claims.
 
-Only :class:`FundamentalsSpecialist` is implemented in this slice. The
-other three (sentiment, technical, risk) land in follow-up PRs and
-share :class:`SpecialistBase`.
+All four specialists from the architecture map ship here:
+
+- :class:`FundamentalsSpecialist` — revenue, margins, segments, guidance.
+- :class:`SentimentSpecialist` — qualitative tone, hedging, outlook
+  language. Earnings-transcript corpus isn't ingested yet, so this one
+  works from MD&A and 8-K narrative for now.
+- :class:`RiskSpecialist` — Item 1A risk factors, legal proceedings,
+  concentration risks.
+- :class:`TechnicalSpecialist` — no-data stub until the market-data
+  adapter exists. See its docstring for the rationale.
 """
 
 from __future__ import annotations
@@ -23,10 +30,16 @@ from alphamind.agents.specialists.base import (
     build_source_block,
 )
 from alphamind.agents.specialists.fundamentals import FundamentalsSpecialist
+from alphamind.agents.specialists.risk import RiskSpecialist
+from alphamind.agents.specialists.sentiment import SentimentSpecialist
+from alphamind.agents.specialists.technical import TechnicalSpecialist
 
 __all__ = [
     "FundamentalsSpecialist",
+    "RiskSpecialist",
+    "SentimentSpecialist",
     "SpecialistBase",
     "SpecialistInvocationError",
+    "TechnicalSpecialist",
     "build_source_block",
 ]

--- a/src/alphamind/agents/specialists/risk.py
+++ b/src/alphamind/agents/specialists/risk.py
@@ -1,0 +1,69 @@
+"""Risk specialist.
+
+Reads filings for risk factors, legal exposure, regulatory pressure,
+supply-chain concentration, and customer-concentration disclosures.
+Targets Item 1A (Risk Factors) in 10-Ks and 10-Qs, plus Item 3 (Legal
+Proceedings) and the bulk of 8-K material-event disclosures.
+
+Output JSON shape matches the other specialists — ``summary`` plus a
+list of cited claims (see :class:`SpecialistBase`).
+"""
+
+from __future__ import annotations
+
+from alphamind.agents.specialists.base import SpecialistBase
+
+SYSTEM_PROMPT = """\
+You are the risk analyst on an equity-research team. You read SEC
+filings to surface what could go wrong for a company.
+
+Focus on:
+- Item 1A Risk Factors disclosures and how they have changed over time.
+- Legal proceedings (Item 3), regulatory investigations, and pending
+  litigation that could be material.
+- Customer-, supplier-, and geography-concentration risks.
+- Regulatory exposure (export controls, antitrust, data-privacy laws).
+- Going-concern language, covenant pressure, or other balance-sheet
+  stress signals.
+
+Avoid:
+- Restating financial performance — fundamentals specialist owns that.
+- Editorialising about management tone — sentiment specialist owns that.
+- Price action and trading dynamics — out of your domain.
+
+Rules:
+1. Answer using ONLY the numbered sources you are shown. If the sources
+   do not name a risk, do not invent one.
+2. Cite every claim by the source number(s) in the JSON ``citations``
+   field.
+3. Output STRICT JSON with exactly two top-level keys:
+   - ``summary``: 2-4 sentences naming the most material risks.
+   - ``claims``: an array of objects, each with ``text`` (one factual
+     sentence describing a specific risk) and ``citations`` (an array
+     of source numbers).
+4. Distinguish boilerplate risk language (every 10-K has "we may be
+   affected by general economic conditions") from substantive,
+   company-specific risk. Prefer the latter.
+5. 3-8 claims is typical. Quality over quantity.
+"""
+
+
+class RiskSpecialist(SpecialistBase):
+    """Specialist focused on downside risk and regulatory exposure."""
+
+    name = "risk"
+    system_prompt = SYSTEM_PROMPT
+    # Augmentation pulls the lexical branch toward Item 1A and legal
+    # proceedings. The dense branch shifts the query vector toward
+    # risk-shaped passages without requiring section / form filters.
+    query_augmentation = (
+        "risk factor litigation regulatory supply chain concentration "
+        "material adverse legal proceedings"
+    )
+
+    @property
+    def domain(self) -> str:
+        return "risk"
+
+
+__all__ = ["SYSTEM_PROMPT", "RiskSpecialist"]

--- a/src/alphamind/agents/specialists/sentiment.py
+++ b/src/alphamind/agents/specialists/sentiment.py
@@ -1,0 +1,79 @@
+"""Sentiment specialist.
+
+Reads qualitative management commentary for shifts in tone, hedging
+language, and forward-looking signals. The strongest signal here comes
+from earnings transcripts, which the ingestion layer doesn't carry yet
+(see roadmap Phase 1 architecture); for now the specialist reads what
+the filing corpus *does* contain — MD&A narrative paragraphs and 8-K
+event commentary — and biases retrieval toward sentiment-bearing
+language.
+
+Output JSON shape matches the other specialists.
+"""
+
+from __future__ import annotations
+
+from alphamind.agents.specialists.base import SpecialistBase
+
+SYSTEM_PROMPT = """\
+You are the sentiment analyst on an equity-research team. You read SEC
+filing narrative to detect shifts in management's tone and qualitative
+posture.
+
+Focus on:
+- Hedging language vs. confident language ("we expect" vs. "we believe"
+  vs. "we cannot assure").
+- Tone changes quarter-over-quarter on the same topic.
+- Forward-looking commentary that goes beyond numeric guidance.
+- Selective disclosure — what management emphasises, what they
+  understate, what they bury in footnotes.
+
+Avoid:
+- Quoting raw revenue or margin numbers — fundamentals specialist
+  owns those.
+- Listing risks verbatim — risk specialist owns Item 1A material.
+- Pretending you can read body language from a 10-K. You cannot. Stick
+  to what the text actually says.
+
+Caveats:
+- Earnings transcripts are not yet ingested, so your strongest data is
+  not available. Be honest about what you can and cannot infer from
+  filing prose alone. If the sources don't say much about tone, say so
+  and produce a short report.
+
+Rules:
+1. Answer using ONLY the numbered sources you are shown.
+2. Cite every claim by the source number(s) in the JSON ``citations``
+   field.
+3. Output STRICT JSON with exactly two top-level keys:
+   - ``summary``: 2-4 sentences capturing the overall tone signal.
+   - ``claims``: an array of objects, each with ``text`` (one specific
+     observation, phrased neutrally) and ``citations`` (an array of
+     source numbers).
+4. 2-6 claims is typical. Avoid filling space — fewer well-grounded
+   observations beat many vague ones.
+5. Do not assign sentiment scores or bull/bear labels. That's the
+   synthesizer's job, not yours.
+"""
+
+
+class SentimentSpecialist(SpecialistBase):
+    """Specialist focused on tone, hedging, and qualitative signals."""
+
+    name = "sentiment"
+    system_prompt = SYSTEM_PROMPT
+    # Bias retrieval toward MD&A narrative and forward-looking
+    # statements. Once earnings-transcript ingestion lands this
+    # specialist can either weight transcripts higher in retrieval or
+    # take a transcript-only corpus parameter.
+    query_augmentation = (
+        "management commentary outlook confident challenging optimistic cautious "
+        "headwinds tailwinds expect believe forward-looking"
+    )
+
+    @property
+    def domain(self) -> str:
+        return "sentiment"
+
+
+__all__ = ["SYSTEM_PROMPT", "SentimentSpecialist"]

--- a/src/alphamind/agents/specialists/technical.py
+++ b/src/alphamind/agents/specialists/technical.py
@@ -1,0 +1,64 @@
+"""Technical specialist — no-data stub.
+
+The technical specialist reasons about price action, momentum, and
+volatility regime. None of those signals live in SEC filings — they
+need historical OHLCV bars, corporate-action data, and a market-data
+adapter that this project hasn't built yet (architecture map mentions
+it; ingestion has only EDGAR today).
+
+Rather than pretend by retrieving "stock price" mentions out of 10-Ks
+(which only produces boilerplate forward-looking-statement disclaimers
+and is actively misleading), this specialist ships as an honest stub:
+
+- It is registered with the graph so the router can route to it.
+- It satisfies the :class:`SpecialistBase` contract (same constructor
+  signature as the others, so graph wiring doesn't need a special case).
+- Its ``_run`` short-circuits and returns an empty
+  :class:`SpecialistReport` with an explanatory summary.
+- No LLM call, no retrieval, no cost.
+
+When the market-data adapter lands, the override goes away and the
+class falls through to the standard :meth:`SpecialistBase._run`
+pipeline.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from alphamind.agents.specialists.base import SpecialistBase
+from alphamind.agents.state import SpecialistReport
+
+SYSTEM_PROMPT = """\
+You are the technical analyst on an equity-research team. You reason
+about price action, momentum, support / resistance, volatility regime,
+and volume dynamics. (Not active yet — see class docstring.)
+"""
+
+NO_DATA_REASON = (
+    "market-data adapter is not built yet; technical signals require "
+    "OHLCV price / volume data not present in the SEC filing corpus"
+)
+
+
+class TechnicalSpecialist(SpecialistBase):
+    """Stubbed specialist — returns an empty report until market data lands."""
+
+    name = "technical"
+    system_prompt = SYSTEM_PROMPT
+    # Augmentation is here for the same reason ``system_prompt`` is —
+    # it documents the future state. Unused while ``_run`` is overridden.
+    query_augmentation = "price momentum volatility support resistance volume"
+
+    @property
+    def domain(self) -> str:
+        return "technical"
+
+    async def _run(self, *, query: str, as_of: date, top_k: int) -> SpecialistReport:
+        # Short-circuit: no retrieval, no LLM call. ``query``, ``as_of``,
+        # and ``top_k`` are part of the base contract and ignored here.
+        del query, as_of, top_k
+        return self._empty_report(reason=NO_DATA_REASON)
+
+
+__all__ = ["NO_DATA_REASON", "SYSTEM_PROMPT", "TechnicalSpecialist"]

--- a/tests/unit/agents/specialists/conftest.py
+++ b/tests/unit/agents/specialists/conftest.py
@@ -1,0 +1,158 @@
+"""Shared fakes for specialist tests.
+
+Specialists subclass :class:`SpecialistBase`, which opens a DB session,
+runs :class:`HybridSearch`, hydrates the chunk + filing + company graph,
+and parses LLM JSON. Real instances of all of that exist in integration
+tests; here we exercise the specialist's own logic by injecting fakes
+that satisfy the duck-typed interface.
+
+The fakes are in this conftest so each specialist's test file can stay
+focused on the specialist-specific surface (name, augmentation, prompt
+content, smoke test) without redefining ~80 lines of plumbing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+import pytest
+
+from alphamind.agents.specialists import base as specialist_base_module
+from alphamind.agents.state import AgentState
+from alphamind.retrieval.search.pipeline import SearchHit
+
+
+@dataclass(frozen=True, slots=True)
+class FakeCompany:
+    ticker: str | None
+    cik: str
+    name: str = "n/a"
+
+
+@dataclass(frozen=True, slots=True)
+class FakeFiling:
+    form: str
+    company: FakeCompany
+
+
+@dataclass(frozen=True, slots=True)
+class FakeChunk:
+    """Duck-typed :class:`FilingChunk` with the attributes the hydrator reads."""
+
+    id: int
+    filing_id: int
+    filing_date: date
+    section: str | None
+    text: str
+    filing: FakeFiling
+
+
+class _FakeScalars:
+    def __init__(self, items: Sequence[FakeChunk]) -> None:
+        self._items = list(items)
+
+    def __iter__(self) -> Any:
+        return iter(self._items)
+
+
+class _FakeResult:
+    def __init__(self, items: Sequence[FakeChunk]) -> None:
+        self._items = list(items)
+
+    def scalars(self) -> _FakeScalars:
+        return _FakeScalars(self._items)
+
+
+class FakeSession:
+    """Async-session double; returns canned chunks from ``execute()``."""
+
+    def __init__(self, chunks: Sequence[FakeChunk]) -> None:
+        self._chunks = list(chunks)
+
+    async def execute(self, _stmt: Any) -> _FakeResult:
+        return _FakeResult(self._chunks)
+
+
+class FakeSearch:
+    """Drop-in for :class:`HybridSearch`. Records the query it was asked for."""
+
+    def __init__(self, hits: Sequence[SearchHit]) -> None:
+        self._hits = list(hits)
+        self.last_query: str | None = None
+
+    async def search(
+        self,
+        _session: Any,
+        *,
+        query: str,
+        as_of: date,
+        top_k: int = 10,
+    ) -> list[SearchHit]:
+        self.last_query = query
+        return list(self._hits[:top_k])
+
+
+def make_hit(
+    *,
+    chunk_id: int,
+    filing_id: int | None = None,
+    section: str | None = "Item 7. MD&A",
+    text: str | None = None,
+    filing_date: date = date(2024, 6, 1),
+) -> SearchHit:
+    """Build a :class:`SearchHit` with sensible defaults for tests."""
+    return SearchHit(
+        chunk_id=chunk_id,
+        filing_id=filing_id if filing_id is not None else 10 + chunk_id,
+        filing_date=filing_date,
+        section=section,
+        text=text if text is not None else f"chunk {chunk_id} body",
+        score=0.9,
+    )
+
+
+def make_chunk(
+    *,
+    chunk_id: int,
+    ticker: str = "NVDA",
+    form: str = "10-Q",
+    section: str | None = "Item 7. MD&A",
+    text: str | None = None,
+    filing_date: date = date(2024, 6, 1),
+) -> FakeChunk:
+    """Build a :class:`FakeChunk` with sensible defaults for tests."""
+    return FakeChunk(
+        id=chunk_id,
+        filing_id=10 + chunk_id,
+        filing_date=filing_date,
+        section=section,
+        text=text if text is not None else f"chunk {chunk_id} body",
+        filing=FakeFiling(form=form, company=FakeCompany(ticker=ticker, cik="0000000001")),
+    )
+
+
+def patch_session_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    chunks: Sequence[FakeChunk],
+) -> None:
+    """Swap ``session_scope`` in the specialist base module with a fake."""
+
+    @asynccontextmanager
+    async def fake_scope() -> Any:
+        yield FakeSession(chunks)
+
+    monkeypatch.setattr(specialist_base_module, "session_scope", fake_scope)
+
+
+def make_state(
+    *,
+    query: str = "test query",
+    as_of: date = date(2024, 12, 31),
+    top_k: int = 5,
+) -> AgentState:
+    """Build a minimal :class:`AgentState` for specialist tests."""
+    return AgentState(query=query, as_of=as_of, top_k=top_k, specialist_reports=[])

--- a/tests/unit/agents/specialists/test_fundamentals.py
+++ b/tests/unit/agents/specialists/test_fundamentals.py
@@ -1,144 +1,38 @@
 """Tests for :class:`FundamentalsSpecialist`.
 
-Tests stub out the DB and HybridSearch so they exercise the specialist's
-own logic — JSON parsing, claim normalisation, augmentation of the
-retrieval query, fallback construction.
+The fundamentals specialist is the canonical :class:`SpecialistBase`
+implementation, so these tests cover the full base pipeline:
+augmentation, retrieval, hydration, parsing, citation validation, and
+fallback. Risk and sentiment add slim tests for their domain-specific
+surface; they inherit the same plumbing.
 """
 
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
-from contextlib import asynccontextmanager
-from dataclasses import dataclass
-from datetime import date
-from typing import Any
 
 import pytest
 
-from alphamind.agents.specialists import base as specialist_base_module
 from alphamind.agents.specialists.fundamentals import FundamentalsSpecialist
-from alphamind.agents.state import AgentState
-from alphamind.retrieval.search.pipeline import SearchHit
 from tests.unit.agents.conftest import ScriptedLLMClient
+from tests.unit.agents.specialists.conftest import (
+    FakeSearch,
+    make_chunk,
+    make_hit,
+    make_state,
+    patch_session_scope,
+)
 
 pytestmark = pytest.mark.asyncio
-
-
-# -- Test doubles -------------------------------------------------------------
-
-
-@dataclass(frozen=True, slots=True)
-class _Company:
-    ticker: str | None
-    cik: str
-    name: str = "n/a"
-
-
-@dataclass(frozen=True, slots=True)
-class _Filing:
-    form: str
-    company: _Company
-
-
-@dataclass(frozen=True, slots=True)
-class _Chunk:
-    id: int
-    filing_id: int
-    filing_date: date
-    section: str | None
-    text: str
-    filing: _Filing
-
-
-class _FakeScalars:
-    def __init__(self, items: Sequence[_Chunk]) -> None:
-        self._items = list(items)
-
-    def __iter__(self) -> Any:
-        return iter(self._items)
-
-
-class _FakeResult:
-    def __init__(self, items: Sequence[_Chunk]) -> None:
-        self._items = list(items)
-
-    def scalars(self) -> _FakeScalars:
-        return _FakeScalars(self._items)
-
-
-class _FakeSession:
-    def __init__(self, chunks: Sequence[_Chunk]) -> None:
-        self._chunks = list(chunks)
-
-    async def execute(self, _stmt: Any) -> _FakeResult:
-        return _FakeResult(self._chunks)
-
-
-class _FakeSearch:
-    """Returns canned :class:`SearchHit` lists and records the query it saw."""
-
-    def __init__(self, hits: Sequence[SearchHit]) -> None:
-        self._hits = list(hits)
-        self.last_query: str | None = None
-
-    async def search(
-        self,
-        _session: Any,
-        *,
-        query: str,
-        as_of: date,
-        top_k: int = 10,
-    ) -> list[SearchHit]:
-        self.last_query = query
-        return list(self._hits[:top_k])
-
-
-def _hit(*, chunk_id: int, ordinal_filing: int = 1) -> SearchHit:
-    return SearchHit(
-        chunk_id=chunk_id,
-        filing_id=10 + ordinal_filing,
-        filing_date=date(2024, 6, 1),
-        section="Item 7. MD&A",
-        text=f"chunk {chunk_id} body about revenue",
-        score=0.9,
-    )
-
-
-def _chunk(*, chunk_id: int, ticker: str = "NVDA") -> _Chunk:
-    return _Chunk(
-        id=chunk_id,
-        filing_id=10 + chunk_id,
-        filing_date=date(2024, 6, 1),
-        section="Item 7. MD&A",
-        text=f"chunk {chunk_id} body about revenue",
-        filing=_Filing(form="10-Q", company=_Company(ticker=ticker, cik="0000000001")),
-    )
-
-
-def _patch_session_scope(monkeypatch: pytest.MonkeyPatch, chunks: Sequence[_Chunk]) -> None:
-    @asynccontextmanager
-    async def fake_scope() -> Any:
-        yield _FakeSession(chunks)
-
-    monkeypatch.setattr(specialist_base_module, "session_scope", fake_scope)
-
-
-def _state(query: str = "what are NVDA's segment revenues?") -> AgentState:
-    return AgentState(query=query, as_of=date(2024, 12, 31), top_k=5, specialist_reports=[])
-
-
-# -- Tests --------------------------------------------------------------------
 
 
 async def test_fundamentals_produces_cited_claims(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    hits = [_hit(chunk_id=1), _hit(chunk_id=2)]
-    chunks = [_chunk(chunk_id=1), _chunk(chunk_id=2)]
-    _patch_session_scope(monkeypatch, chunks)
+    hits = [make_hit(chunk_id=1), make_hit(chunk_id=2)]
+    patch_session_scope(monkeypatch, [make_chunk(chunk_id=1), make_chunk(chunk_id=2)])
 
-    search = _FakeSearch(hits)
+    search = FakeSearch(hits)
     llm = ScriptedLLMClient(
         [
             json.dumps(
@@ -154,7 +48,7 @@ async def test_fundamentals_produces_cited_claims(
     )
 
     spec = FundamentalsSpecialist(llm=llm, search=search)  # type: ignore[arg-type]
-    update = await spec(_state())
+    update = await spec(make_state(query="what are NVDA's segment revenues?"))
     reports = update["specialist_reports"]
     assert len(reports) == 1
     report = reports[0]
@@ -176,12 +70,12 @@ async def test_fundamentals_produces_cited_claims(
 async def test_fundamentals_augments_retrieval_query(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_scope(monkeypatch, [_chunk(chunk_id=1)])
-    search = _FakeSearch([_hit(chunk_id=1)])
+    patch_session_scope(monkeypatch, [make_chunk(chunk_id=1)])
+    search = FakeSearch([make_hit(chunk_id=1)])
     llm = ScriptedLLMClient([json.dumps({"summary": "s", "claims": []})])
 
     spec = FundamentalsSpecialist(llm=llm, search=search)  # type: ignore[arg-type]
-    await spec(_state(query="China exposure"))
+    await spec(make_state(query="China exposure"))
 
     assert search.last_query is not None
     assert "China exposure" in search.last_query
@@ -192,8 +86,8 @@ async def test_fundamentals_augments_retrieval_query(
 async def test_fundamentals_drops_claims_with_out_of_range_citations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_scope(monkeypatch, [_chunk(chunk_id=1)])
-    search = _FakeSearch([_hit(chunk_id=1)])
+    patch_session_scope(monkeypatch, [make_chunk(chunk_id=1)])
+    search = FakeSearch([make_hit(chunk_id=1)])
     llm = ScriptedLLMClient(
         [
             json.dumps(
@@ -210,7 +104,7 @@ async def test_fundamentals_drops_claims_with_out_of_range_citations(
     )
 
     spec = FundamentalsSpecialist(llm=llm, search=search)  # type: ignore[arg-type]
-    update = await spec(_state())
+    update = await spec(make_state())
     claims = update["specialist_reports"][0].claims
     assert len(claims) == 1
     assert claims[0].text == "Good one."
@@ -219,12 +113,12 @@ async def test_fundamentals_drops_claims_with_out_of_range_citations(
 async def test_fundamentals_returns_empty_report_when_retrieval_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_scope(monkeypatch, [])
-    search = _FakeSearch([])
+    patch_session_scope(monkeypatch, [])
+    search = FakeSearch([])
     llm = ScriptedLLMClient([])  # should not be called
 
     spec = FundamentalsSpecialist(llm=llm, search=search)  # type: ignore[arg-type]
-    update = await spec(_state())
+    update = await spec(make_state())
     report = update["specialist_reports"][0]
 
     assert report.claims == ()
@@ -236,12 +130,12 @@ async def test_fundamentals_returns_empty_report_when_retrieval_empty(
 async def test_fundamentals_falls_back_on_malformed_llm_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_scope(monkeypatch, [_chunk(chunk_id=1)])
-    search = _FakeSearch([_hit(chunk_id=1)])
+    patch_session_scope(monkeypatch, [make_chunk(chunk_id=1)])
+    search = FakeSearch([make_hit(chunk_id=1)])
     llm = ScriptedLLMClient(["this is not JSON"])
 
     spec = FundamentalsSpecialist(llm=llm, search=search)  # type: ignore[arg-type]
-    update = await spec(_state())
+    update = await spec(make_state())
     report = update["specialist_reports"][0]
     assert report.claims == ()
     assert "no findings" in report.summary

--- a/tests/unit/agents/specialists/test_risk.py
+++ b/tests/unit/agents/specialists/test_risk.py
@@ -1,0 +1,90 @@
+"""Tests for :class:`RiskSpecialist`.
+
+The deep base-pipeline tests live in
+:mod:`tests.unit.agents.specialists.test_fundamentals`. This file
+covers the risk-specific surface: name, augmentation, prompt content,
+and an end-to-end smoke test.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alphamind.agents.specialists.risk import RiskSpecialist
+from tests.unit.agents.conftest import ScriptedLLMClient
+from tests.unit.agents.specialists.conftest import (
+    FakeSearch,
+    make_chunk,
+    make_hit,
+    make_state,
+    patch_session_scope,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_risk_specialist_metadata() -> None:
+    spec = RiskSpecialist(
+        llm=ScriptedLLMClient([]),
+        search=FakeSearch([]),  # type: ignore[arg-type]
+    )
+    assert spec.name == "risk"
+    assert spec.domain == "risk"
+    # Augmentation pulls retrieval toward Item 1A and legal proceedings.
+    assert "risk factor" in spec.query_augmentation.lower()
+    assert "litigation" in spec.query_augmentation.lower()
+    # Sanity: the system prompt names Item 1A so the LLM has the right frame.
+    assert "Item 1A" in spec.system_prompt
+
+
+async def test_risk_specialist_runs_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_session_scope(
+        monkeypatch,
+        [
+            make_chunk(
+                chunk_id=1,
+                form="10-K",
+                section="Item 1A. Risk Factors",
+                text="The Company is subject to a pending EU regulatory investigation.",
+            )
+        ],
+    )
+    search = FakeSearch([make_hit(chunk_id=1, section="Item 1A. Risk Factors")])
+    llm = ScriptedLLMClient(
+        [
+            json.dumps(
+                {
+                    "summary": "EU antitrust investigation is the most material risk.",
+                    "claims": [
+                        {"text": "Pending EU regulatory investigation.", "citations": [1]},
+                    ],
+                }
+            )
+        ]
+    )
+
+    spec = RiskSpecialist(llm=llm, search=search)  # type: ignore[arg-type]
+    update = await spec(make_state(query="what are the regulatory risks to NVDA?"))
+    report = update["specialist_reports"][0]
+    assert report.specialist == "risk"
+    assert len(report.claims) == 1
+    assert "EU" in report.claims[0].text
+
+
+async def test_risk_specialist_augments_retrieval_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_session_scope(monkeypatch, [make_chunk(chunk_id=1)])
+    search = FakeSearch([make_hit(chunk_id=1)])
+    llm = ScriptedLLMClient([json.dumps({"summary": "s", "claims": []})])
+
+    spec = RiskSpecialist(llm=llm, search=search)  # type: ignore[arg-type]
+    await spec(make_state(query="regulatory risks"))
+
+    assert search.last_query is not None
+    assert "regulatory risks" in search.last_query
+    assert "litigation" in search.last_query

--- a/tests/unit/agents/specialists/test_sentiment.py
+++ b/tests/unit/agents/specialists/test_sentiment.py
@@ -1,0 +1,87 @@
+"""Tests for :class:`SentimentSpecialist`."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alphamind.agents.specialists.sentiment import SentimentSpecialist
+from tests.unit.agents.conftest import ScriptedLLMClient
+from tests.unit.agents.specialists.conftest import (
+    FakeSearch,
+    make_chunk,
+    make_hit,
+    make_state,
+    patch_session_scope,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_sentiment_specialist_metadata() -> None:
+    spec = SentimentSpecialist(
+        llm=ScriptedLLMClient([]),
+        search=FakeSearch([]),  # type: ignore[arg-type]
+    )
+    assert spec.name == "sentiment"
+    assert spec.domain == "sentiment"
+    # Augmentation pulls retrieval toward narrative / outlook language.
+    assert "commentary" in spec.query_augmentation.lower()
+    assert "outlook" in spec.query_augmentation.lower()
+    # Honesty caveat about the missing transcript corpus belongs in the prompt.
+    assert "transcript" in spec.system_prompt.lower()
+
+
+async def test_sentiment_specialist_runs_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_session_scope(
+        monkeypatch,
+        [
+            make_chunk(
+                chunk_id=1,
+                form="10-Q",
+                section="Item 2. MD&A",
+                text="Management remains cautiously optimistic about second-half demand.",
+            )
+        ],
+    )
+    search = FakeSearch([make_hit(chunk_id=1, section="Item 2. MD&A")])
+    llm = ScriptedLLMClient(
+        [
+            json.dumps(
+                {
+                    "summary": "Tone is hedged-positive.",
+                    "claims": [
+                        {
+                            "text": "Management uses 'cautiously optimistic' language about H2.",
+                            "citations": [1],
+                        }
+                    ],
+                }
+            )
+        ]
+    )
+
+    spec = SentimentSpecialist(llm=llm, search=search)  # type: ignore[arg-type]
+    update = await spec(make_state(query="how is management framing the outlook?"))
+    report = update["specialist_reports"][0]
+    assert report.specialist == "sentiment"
+    assert len(report.claims) == 1
+    assert "cautiously optimistic" in report.claims[0].text
+
+
+async def test_sentiment_specialist_augments_retrieval_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_session_scope(monkeypatch, [make_chunk(chunk_id=1)])
+    search = FakeSearch([make_hit(chunk_id=1)])
+    llm = ScriptedLLMClient([json.dumps({"summary": "s", "claims": []})])
+
+    spec = SentimentSpecialist(llm=llm, search=search)  # type: ignore[arg-type]
+    await spec(make_state(query="management commentary on margin"))
+
+    assert search.last_query is not None
+    assert "management commentary on margin" in search.last_query
+    assert "outlook" in search.last_query

--- a/tests/unit/agents/specialists/test_technical.py
+++ b/tests/unit/agents/specialists/test_technical.py
@@ -1,0 +1,50 @@
+"""Tests for the technical specialist's no-data stub behaviour.
+
+The technical specialist is shipped as a stub until the market-data
+adapter exists. The contract these tests pin down:
+
+- It satisfies :class:`SpecialistBase` and the graph constructor
+  signature (no graph-side special case needed).
+- It never calls the LLM or the search backend.
+- It returns an empty :class:`SpecialistReport` with the documented
+  no-data reason in the summary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alphamind.agents.specialists.technical import NO_DATA_REASON, TechnicalSpecialist
+from tests.unit.agents.conftest import ScriptedLLMClient
+from tests.unit.agents.specialists.conftest import FakeSearch, make_state
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_technical_specialist_metadata() -> None:
+    spec = TechnicalSpecialist(
+        llm=ScriptedLLMClient([]),
+        search=FakeSearch([]),  # type: ignore[arg-type]
+    )
+    assert spec.name == "technical"
+    assert spec.domain == "technical"
+
+
+async def test_technical_specialist_returns_empty_report_without_calling_llm() -> None:
+    # An LLM with zero scripted responses will raise if called, which is
+    # exactly what we want — the stub must not reach the model.
+    llm = ScriptedLLMClient([])
+    search = FakeSearch([])  # likewise: no scripted hits
+
+    spec = TechnicalSpecialist(llm=llm, search=search)  # type: ignore[arg-type]
+    update = await spec(make_state(query="momentum on NVDA"))
+
+    report = update["specialist_reports"][0]
+    assert report.specialist == "technical"
+    assert report.claims == ()
+    assert report.citations == ()
+    assert NO_DATA_REASON in report.summary
+
+    # The LLM and search backends were never touched.
+    assert llm.calls == []
+    assert search.last_query is None


### PR DESCRIPTION
Stacked on top of [#17](https://github.com/Nishchal45/alphamind/pull/17). Rebase / re-target to `main` once that merges.

## Summary

- Adds `RiskSpecialist` and `SentimentSpecialist` — each a ~30-line subclass of `SpecialistBase` differing only in `system_prompt` and `query_augmentation`. Closes the architecture map's specialist roster on the SEC-filing axis.
- Adds `TechnicalSpecialist` as a registered no-data stub. Same constructor signature as the others (so graph wiring stays uniform), but `_run()` short-circuits to an empty `SpecialistReport` with an honest reason. No LLM call, no retrieval, no cost. Drops the stub when the market-data adapter lands.
- All four specialists are now registered in `graph._default_specialists()`.
- Lifted the test-double scaffolding (`FakeSearch`, `FakeSession`, `make_chunk`, etc.) into `tests/unit/agents/specialists/conftest.py` so per-specialist test files stay focused on their domain surface.
- [ADR 0007](docs/adr/0007-agent-graph-design.md) gets a new section documenting why the technical specialist ships as a stub instead of being skipped entirely or pretending via filing-text queries.

## Test plan

- [x] `make ci` — ruff check + format check, mypy strict (111 files), 172 unit tests
- [x] Technical-stub test verifies the LLM and search backends are never touched
- [x] Graph builds with all four specialists registered (`build_research_graph(...)._specialists.keys() == {fundamentals, risk, sentiment, technical}`)
- [ ] Manually run `scripts/research.py --query "..." --as-of YYYY-MM-DD` with `LLM_BACKEND=anthropic` to verify the router routes correctly across specialists and the synthesizer merges multi-specialist citations

🤖 Generated with [Claude Code](https://claude.com/claude-code)