### PR TITLE
feat(api): FastAPI serving layer with SSE-streamed agent graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,16 @@ All notable changes to this project will be documented in this file. The format 
 - `scripts/research.py` — first agentic end-to-end demo of the project. Runs the LangGraph DAG against ingested filings with the same `--as-of` discipline as `ask.py`.
 - ADR 0007 documenting the agent-graph design (LangGraph, typed state, scaffolding, the renumber-before-LLM contract, LLM-judge critic, graph-wide fallback policy).
 - Runbook `docs/runbooks/research.md` covering invocation, expected output, and failure modes.
+- `alphamind.api` package: FastAPI app via `create_app()` factory and a `lifespan` that builds the `ResearchGraph` once and disposes engine + embedder on shutdown. Pydantic request / response schemas live in `alphamind.api.schemas`, separate from the agent dataclasses; converted at the boundary.
+- `POST /research` — runs the agent graph and streams progress as Server-Sent Events (`router-decision`, one `specialist-report` per specialist in completion order, `thesis`, `critic-report`, then `done` or `error`). The synthesizer's answer arrives as one event, not token-by-token; token streaming requires growing the `LLMClient` protocol and lands in a follow-up.
+- `GET /healthz` (liveness, no I/O) and `GET /readyz` (Postgres reachability probe via `SELECT 1`, returns `503` when the DB is unreachable).
+- `ResearchGraph.stream_updates()` — async iterator over `(node_name, state_update)` pairs from LangGraph's `astream(stream_mode="updates")`. The SSE adapter (`alphamind.api.sse`) converts these to typed event payloads.
+- `make serve` Makefile target running `uvicorn --factory alphamind.api.app:create_app --reload`.
+- ADR 0008 documenting FastAPI + SSE choices, why pydantic schemas are separate from the agent dataclasses, and what's deferred (token streaming, Redis cache, cost routing).
+- Runbook `docs/runbooks/api.md` covering invocation, event semantics, proxy gotchas, and failure modes.
 
 ### Changed
 - `EdgarClient` no longer sends a fixed `Accept: application/json` header — the same client now hits both JSON endpoints under `data.sec.gov` and HTML/XML bodies under `www.sec.gov/Archives`.
-- README roadmap: Phase 2 is now complete (chunker, embeddings, hybrid retrieval, cross-encoder rerank). Phase 3 is in progress — LLM provider integration shipped, real sentence-transformer embedder + cross-encoder rerank shipped, and the LangGraph skeleton + fundamentals specialist + synthesizer + critic now ship in this slice. Remaining specialists (sentiment, technical, risk) land in follow-up PRs.
+- README roadmap: Phase 2 is now complete (chunker, embeddings, hybrid retrieval, cross-encoder rerank). Phase 3's agent team is feature-complete on the SEC-filing axis (router, fundamentals + critic shipped here; sentiment + risk + technical-stub queued in the stacked PR). Phase 5's first slice now ships: FastAPI app, SSE streaming, health probes. Redis cache, cost routing, token streaming, auth all deferred.
 
 [Unreleased]: https://github.com/Nishchal45/alphamind/compare/HEAD...HEAD

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 .PHONY: help install dev lint format typecheck test test-integration test-cov test-all \
 	ci clean compose-up compose-down compose-logs \
-	migrate migration downgrade db-reset healthcheck
+	migrate migration downgrade db-reset healthcheck serve
 
 UV := uv
 
@@ -75,3 +75,6 @@ db-reset: ## Drop and recreate the postgres volume (destructive)
 
 healthcheck: ## Verify postgres, pgvector, and redis are reachable
 	$(UV) run python scripts/healthcheck.py
+
+serve: ## Run the FastAPI app locally with autoreload
+	$(UV) run uvicorn --factory alphamind.api.app:create_app --reload --host 0.0.0.0 --port 8000

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ sentiment / technical / risk land in follow-up PRs and slot in via the
 shared `SpecialistBase`. Design rationale in [`docs/adr/0007-agent-graph-design.md`](docs/adr/0007-agent-graph-design.md);
 operational details in [`docs/runbooks/research.md`](docs/runbooks/research.md).
 
+### Running the API
+
+```bash
+make serve  # uvicorn --factory alphamind.api.app:create_app --reload
+curl -N -X POST http://localhost:8000/research \
+  -H "Content-Type: application/json" \
+  -d '{"query":"NVDA China exposure","as_of":"2024-12-31"}'
+```
+
+`POST /research` runs the agent graph and streams progress as Server-Sent
+Events (one event per node completion). `GET /healthz` and `GET /readyz`
+are k8s-shaped liveness / readiness probes. Design rationale in
+[`docs/adr/0008-fastapi-serving-and-sse.md`](docs/adr/0008-fastapi-serving-and-sse.md);
+operational details in [`docs/runbooks/api.md`](docs/runbooks/api.md).
+
 Example output:
 
 ```
@@ -119,7 +134,7 @@ CIK          TICKER     SEEN  WRITTEN  NAME
 - [x] Phase 2 — filing-body ingestion, finance-aware chunking, embeddings, hybrid retrieval (BM25 + pgvector + RRF + cross-encoder rerank) with a hard time-horizon filter at every stage
 - [ ] Phase 3 — LLM provider integration (Anthropic adapter shipped), real sentence-transformer embedder + cross-encoder rerank (shipped), LangGraph agent team (router + fundamentals specialist + synthesizer + critic shipped; remaining specialists in follow-ups)
 - [ ] Phase 4 — fine-tuned SLM on financial text (LoRA / QLoRA)
-- [ ] Phase 5 — FastAPI serving layer with streaming, caching, cost routing
+- [ ] Phase 5 — FastAPI serving layer with streaming (SSE shipped), caching, cost routing (caching and cost routing in follow-ups)
 - [ ] Phase 6 — backtest harness, evaluation set, public result dashboard
 
 ## Disclaimer

--- a/docs/adr/0008-fastapi-serving-and-sse.md
+++ b/docs/adr/0008-fastapi-serving-and-sse.md
@@ -1,0 +1,137 @@
+# 8. FastAPI serving + Server-Sent Events
+
+- **Status**: accepted
+- **Date**: 2026-05-19
+
+## Context
+
+ADR 0007 shipped the agent graph behind a CLI (`scripts/research.py`).
+The roadmap promises a serving layer — async streaming endpoints, a
+Redis cache, model routing for cost. This ADR records the first cut:
+the FastAPI app and how it streams agent-graph progress to clients.
+Cache and cost routing are out of scope for this slice.
+
+Two specific design questions to nail down:
+
+1. How does the API expose graph progress without blocking until the
+   whole run finishes? The agent team typically takes 10–30 seconds
+   end-to-end. A request that returns one JSON blob at the end is a
+   bad UX, especially once a frontend is in front of it.
+2. The :class:`alphamind.llm.base.LLMClient` protocol doesn't support
+   streaming completions yet (ADR 0006 deferred it explicitly). What
+   does "streaming" mean for this slice?
+
+## Decision
+
+A FastAPI app with one streaming endpoint and two probes.
+
+### Endpoints
+
+| Method | Path        | Purpose |
+| ------ | ----------- | ------- |
+| POST   | `/research` | Run the agent graph, stream progress as SSE. |
+| GET    | `/healthz`  | Liveness — no I/O, always `200 {status: ok}`. |
+| GET    | `/readyz`   | Readiness — `200` when Postgres responds to `SELECT 1`, else `503`. |
+
+### Streaming model: SSE over node-completion events, not tokens
+
+LangGraph's `astream(stream_mode="updates")` yields
+`{node_name: state_update}` after each node completes. We forward
+those as Server-Sent Events:
+
+| LangGraph node | SSE event | Payload schema |
+| -------------- | --------- | -------------- |
+| `router` | `router-decision` | `{specialists, rationale}` |
+| `fundamentals` / `sentiment` / `risk` / `technical` | `specialist-report` | `{specialist, summary, claims[], citations[]}` |
+| `synthesizer` | `thesis` | `{answer, bull[], bear[], citations[]}` |
+| `critic` | `critic-report` | `{unsupported[], notes, ok}` |
+| (graph end) | `done` | `{}` (sentinel) |
+| (graph raised) | `error` | `{message}` |
+
+The synthesizer's answer arrives as one `thesis` event — not
+token-by-token. Real token streaming requires growing `LLMClient`
+with a streaming method and threading the token iterator through the
+synthesizer node. Both happen in a follow-up; the protocol grows when
+it's the cheapest path, not preemptively.
+
+### Why SSE instead of WebSockets
+
+The data flow is one-way from server to client. WebSockets would
+work but cost an upgrade handshake and a bidirectional framing layer
+we don't need. SSE rides on top of HTTP, plays well with proxies and
+load balancers, and JavaScript's built-in `EventSource` does the
+client side for free.
+
+The trade-off: SSE doesn't support binary frames and reconnect
+semantics are weaker than WebSockets'. Neither matters for streaming
+JSON events from a research run that takes ~30 seconds at most.
+
+### Why a factory + lifespan, not a module-level app
+
+`create_app()` builds a fresh app per call. Two reasons:
+
+- **Test isolation.** Each test gets its own app with its own
+  dependency overrides; no global state leaks across tests.
+- **Explicit entry point.** `uvicorn --factory alphamind.api.app:create_app`
+  documents the contract instead of relying on a bare `app =
+  FastAPI()` somewhere in the module.
+
+The lifespan owns three things: building the `ResearchGraph` once
+(so the LLM client + embedder factories' singleton caching has a
+host that survives across requests), and disposing the engine +
+embedder HTTP clients on shutdown.
+
+### Pydantic schemas live separate from the agent dataclasses
+
+The leaf records on `AgentState` (`Citation`, `Claim`,
+`SpecialistReport`, `Thesis`, `CriticReport`) are frozen dataclasses.
+The HTTP surface uses Pydantic models that mirror them.
+
+Why not share types? Two reasons:
+
+- **Different audiences.** The dataclasses optimise for immutability
+  and ergonomic Python (pydantic's validation overhead is wasted on
+  internal transport). The HTTP schemas optimise for OpenAPI doc
+  generation and JSON validation at the boundary.
+- **Avoids leaking internal shape.** Future refactors that change
+  how the graph carries state internally don't break clients. The
+  conversion lives in one place (`alphamind.api.schemas`) and is
+  easy to keep stable.
+
+The cost: small. Each leaf record gets a ~10-line `from_dataclass`
+helper. The duplication is intentional separation, not duplication
+that the type system could eliminate.
+
+### Error handling
+
+Three layers, narrowest first:
+
+1. **Pydantic validation** rejects bad requests with `422`. This
+   covers empty queries, missing `as_of`, `top_k` out of range.
+2. **Node failures** — handled inside the graph (every node has a
+   fallback path that produces a valid empty update). Clients see a
+   normal-looking event with empty fields and an explanatory
+   summary; the run completes.
+3. **Graph raising mid-stream** — caught by the SSE adapter, which
+   emits a final `error` event and closes the stream. The HTTP
+   status was already `200` by the time bytes started flowing, so
+   there's no nice way to signal failure via status code; the
+   `error` event is the signal.
+
+## Consequences
+
+- `scripts/research.py` and the API both call the same graph through
+  the same protocol. The CLI is the developer-loop entry point; the
+  API is the production entry point. Behaviour parity is automatic.
+- The agent graph gained a `stream_updates(payload)` method that
+  yields `(node_name, state_update)` pairs. This is the only new
+  surface on the agent layer needed to support streaming.
+- Token streaming, Redis caching, cost routing, and auth are all
+  deferred. None of them block running the API end-to-end against
+  ingested data; they fold in cleanly when each becomes the most
+  valuable next slice.
+- The technical specialist's no-data stub is still wired through. A
+  client that asks a technical-flavoured question will get a
+  `specialist-report` event with empty `claims` / `citations` and
+  the documented "no market-data adapter" reason in the summary.
+  This is honest, not a bug.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,3 +29,4 @@ An ADR starts in `proposed` status, moves to `accepted` when merged, and may lat
 - [0005 — Retrieval pipeline: chunker, embedder, hybrid search](0005-retrieval-pipeline-design.md)
 - [0006 — LLM provider integration](0006-llm-provider-integration.md)
 - [0007 — Agent graph design](0007-agent-graph-design.md)
+- [0008 — FastAPI serving + Server-Sent Events](0008-fastapi-serving-and-sse.md)

--- a/docs/runbooks/api.md
+++ b/docs/runbooks/api.md
@@ -1,0 +1,130 @@
+# Runbook — FastAPI service
+
+The agent graph behind an HTTP surface. CLI (`scripts/research.py`)
+remains; the API is the productised path. Design rationale in
+[ADR 0008](../adr/0008-fastapi-serving-and-sse.md).
+
+## What it does
+
+```
+POST /research { query, as_of, top_k }
+  → SSE stream:
+      event: router-decision     data: {...}
+      event: specialist-report   data: {...}   (one per specialist)
+      event: thesis              data: {...}
+      event: critic-report       data: {...}
+      event: done                data: {}
+
+GET /healthz   → 200 {status: ok}                       (liveness)
+GET /readyz    → 200 ok / 503 down                      (Postgres reachability)
+GET /docs      → Swagger UI
+GET /openapi.json
+```
+
+## Running locally
+
+```bash
+# real models / embeddings
+LLM_BACKEND=anthropic ANTHROPIC_API_KEY=sk-ant-... \
+EMBEDDING_BACKEND=gemini GOOGLE_API_KEY=... \
+  make serve
+
+# defaults — runs end-to-end with stubs (echo LLM, deterministic embedder)
+make serve
+```
+
+`make serve` runs `uvicorn --factory alphamind.api.app:create_app
+--reload --host 0.0.0.0 --port 8000`. Adjust host/port as needed.
+
+## Calling it
+
+```bash
+curl -N -X POST http://localhost:8000/research \
+  -H "Content-Type: application/json" \
+  -d '{"query":"NVDA China exposure","as_of":"2024-12-31","top_k":8}'
+```
+
+The `-N` flag is critical — without it, curl buffers the SSE stream
+and you see nothing until the run finishes, defeating the point.
+
+Expected output (truncated):
+
+```
+event: router-decision
+data: {"specialists":["fundamentals","risk"],"rationale":"..."}
+
+event: specialist-report
+data: {"specialist":"fundamentals","summary":"...","claims":[...],"citations":[...]}
+
+event: specialist-report
+data: {"specialist":"risk","summary":"...","claims":[...],"citations":[...]}
+
+event: thesis
+data: {"answer":"...","bull":[...],"bear":[...],"citations":[...]}
+
+event: critic-report
+data: {"unsupported":[],"notes":"well-supported","ok":true}
+
+event: done
+data: {}
+```
+
+From JavaScript:
+
+```js
+const res = await fetch("/research", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ query, as_of, top_k: 8 }),
+});
+// Use ReadableStream + TextDecoder, or a small SSE parser. Browsers'
+// built-in EventSource only supports GET; for POST you parse the
+// chunks manually.
+```
+
+## Reading the events
+
+| Event | When fired | Payload |
+| ----- | ---------- | ------- |
+| `router-decision` | Right after the router runs (once) | `specialists`, `rationale` |
+| `specialist-report` | After each specialist completes; parallel branches surface in completion order | `specialist`, `summary`, `claims`, `citations` |
+| `thesis` | After the synthesizer (once) | `answer`, `bull`, `bear`, `citations` |
+| `critic-report` | After the critic (once) | `unsupported`, `notes`, `ok` |
+| `done` | Terminal sentinel after a clean run | `{}` |
+| `error` | Terminal sentinel after a graph-level failure | `{message}` |
+
+Clients should treat `done` and `error` as terminal and close the
+connection. A connection that closes without either signal indicates
+the network dropped — retry or surface the failure.
+
+## Failure modes
+
+| Symptom | Likely cause | Action |
+| ------- | ------------ | ------ |
+| `422 Unprocessable Entity` | Pydantic rejected the body — missing `as_of`, blank `query`, `top_k` outside [1, 50] | Read the response body; it names the offending field |
+| `503` on `/readyz` | Postgres unreachable | Check `make compose-up`; confirm `DATABASE_URL` |
+| Stream ends without `done` or `error` | Connection dropped (proxy timeout, client cancelled) | Retry; check proxy idle-timeout |
+| `event: error` mid-stream | The graph raised. Inner-node errors are caught inside the graph, so this means input validation slipped through or a wiring bug. | Read the `message`; check server logs |
+| All `specialist-report` events have empty `claims` | No chunks matched `as_of` cutoff | Re-ingest filings or widen `as_of` |
+| `technical` specialist always returns empty | Expected — no-data stub until the market-data adapter exists | Ignore or treat as a TODO |
+
+## Operational notes
+
+- `--as-of` is mandatory (same reasoning as `ask.py` and
+  `research.py`; see ADR 0005). There is no default — the API
+  enforces this with a Pydantic `Field(...)` with no default.
+- The lifespan builds the `ResearchGraph` once and reuses it across
+  requests. Cold-start cost: the LLM client + embedder factories
+  initialise on first request, not at startup. Cold-request latency
+  is ~100ms higher than warm.
+- Server-Sent Events stream over a long-lived HTTP connection. Any
+  proxy in front of the service must allow long-lived connections
+  (nginx: `proxy_read_timeout 300s; proxy_buffering off;`).
+- The agent graph runs the LLM 6+ times per request (router, ~4
+  specialists, synthesizer, critic). Cost per request is non-trivial
+  with frontier models — Redis caching of identical
+  `(query, as_of)` pairs lands in a follow-up.
+- Token-level streaming of the synthesizer answer is **not** in this
+  cut. The `thesis` event arrives as one chunk. The follow-up that
+  grows `LLMClient` with a streaming method will surface tokens as
+  incremental `thesis-delta` events.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
     "numpy>=1.26",
     "anthropic>=0.40",
     "langgraph>=0.2.50",
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.32",
+    "sse-starlette>=2.1",
 ]
 
 [project.optional-dependencies]

--- a/src/alphamind/agents/graph.py
+++ b/src/alphamind/agents/graph.py
@@ -16,7 +16,7 @@ PR can register sentiment/technical/risk without touching this file.
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
 from typing import Any
 
 from langgraph.graph import END, START, StateGraph
@@ -122,6 +122,29 @@ class ResearchGraph:
         # public surface honest without leaking ``Any`` to callers.
         result: AgentState = await self._compiled.ainvoke(state)
         return result
+
+    async def stream_updates(
+        self,
+        payload: GraphInput,
+    ) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+        """Yield ``(node_name, state_update)`` pairs as each node completes.
+
+        Backs the FastAPI streaming endpoint: the API converts each
+        update into a Server-Sent Event payload. ``stream_mode="updates"``
+        emits only the delta each node returned, which is exactly the
+        payload the client needs — full state would re-send earlier
+        specialist reports on every event.
+
+        The LangGraph runtime preserves node order for sequential edges
+        and emits parallel-branch events as they complete (so two
+        specialists running concurrently surface in completion order,
+        not declaration order).
+        """
+
+        state = payload.to_state()
+        async for update in self._compiled.astream(state, stream_mode="updates"):
+            for node_name, state_update in update.items():
+                yield node_name, state_update
 
 
 def _route_to_specialists(available: set[str]) -> Any:

--- a/src/alphamind/api/__init__.py
+++ b/src/alphamind/api/__init__.py
@@ -1,0 +1,23 @@
+"""FastAPI serving layer for AlphaMind.
+
+Phase 5 of the project. The CLI (`scripts/research.py`) is the
+developer entrypoint; this package is the productised one. An ASGI
+app exposes:
+
+- ``POST /research`` — runs the agent graph and streams progress as
+  Server-Sent Events (one event per node completion). The final
+  thesis arrives as a single event; token-level streaming lands in
+  a follow-up that extends the :class:`alphamind.llm.base.LLMClient`
+  protocol.
+- ``GET /healthz`` — liveness.
+- ``GET /readyz`` — readiness; verifies Postgres is reachable.
+
+Run locally with ``make serve`` or
+``uv run uvicorn --factory alphamind.api.app:create_app``.
+"""
+
+from __future__ import annotations
+
+from alphamind.api.app import create_app
+
+__all__ = ["create_app"]

--- a/src/alphamind/api/app.py
+++ b/src/alphamind/api/app.py
@@ -1,0 +1,81 @@
+"""FastAPI application factory + lifespan.
+
+The factory pattern (vs. a module-level ``app = FastAPI()``) is
+deliberate:
+
+- Tests construct their own app with overridden dependencies; they
+  must not share global state with the production app.
+- ``uvicorn --factory`` calls this function explicitly, which makes
+  the contract obvious: ``create_app()`` is the only public entry
+  point.
+
+The lifespan owns the lifecycle of singletons that hold async
+resources — the research graph (which in turn holds the LLM client
+and the embedder), the SQL engine, the embedder's HTTP client. They
+are constructed lazily on first use and disposed cleanly on shutdown.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from alphamind.agents.graph import get_research_graph
+from alphamind.api.routes import health, research
+from alphamind.config import get_settings
+from alphamind.db.session import dispose_engine
+from alphamind.retrieval.embeddings.factory import dispose_embedder
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Build the research graph once; tear down async resources on exit.
+
+    The graph itself is cheap to construct — the expensive bits (LLM
+    client, embedder HTTP session) live behind cached factories. But
+    holding the graph in ``app.state`` is what makes
+    :func:`alphamind.api.dependencies.get_research_graph_dep` work
+    without each request rebuilding the wiring.
+    """
+
+    settings = get_settings()
+    logger.info(
+        "alphamind.api starting environment=%s llm_backend=%s embedding_backend=%s",
+        settings.environment,
+        settings.llm_backend,
+        settings.embedding_backend,
+    )
+
+    app.state.research_graph = get_research_graph()
+    try:
+        yield
+    finally:
+        logger.info("alphamind.api shutting down — disposing async resources")
+        await dispose_embedder()
+        await dispose_engine()
+
+
+def create_app() -> FastAPI:
+    """Build the AlphaMind FastAPI app."""
+
+    app = FastAPI(
+        title="AlphaMind",
+        description=(
+            "Agentic equity-research API. Runs the LangGraph agent team "
+            "over ingested SEC filings and streams progress as "
+            "Server-Sent Events."
+        ),
+        version="0.1.0",
+        lifespan=lifespan,
+    )
+    app.include_router(health.router)
+    app.include_router(research.router)
+    return app
+
+
+__all__ = ["create_app", "lifespan"]

--- a/src/alphamind/api/dependencies.py
+++ b/src/alphamind/api/dependencies.py
@@ -1,0 +1,35 @@
+"""FastAPI dependency providers.
+
+Centralised so route handlers depend on these names, not on the
+underlying factories directly. Tests override these via
+``app.dependency_overrides`` to inject fakes — that's the seam.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from fastapi import Request
+
+from alphamind.agents.graph import ResearchGraph
+
+
+def get_research_graph_dep(request: Request) -> ResearchGraph:
+    """Pull the process-wide :class:`ResearchGraph` out of app state.
+
+    The graph is constructed once in the lifespan and reused across
+    requests. Reconstructing per-request would defeat the LLM-client
+    singleton caching in :mod:`alphamind.llm.factory` and the
+    embedder caching in :mod:`alphamind.retrieval.embeddings.factory`.
+    """
+
+    graph = getattr(request.app.state, "research_graph", None)
+    if graph is None:  # pragma: no cover — guarded by lifespan in production
+        raise RuntimeError(
+            "research_graph not initialised; app lifespan did not run "
+            "(are you constructing the FastAPI app without create_app()?)"
+        )
+    return cast("ResearchGraph", graph)
+
+
+__all__ = ["get_research_graph_dep"]

--- a/src/alphamind/api/routes/__init__.py
+++ b/src/alphamind/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP route handlers."""

--- a/src/alphamind/api/routes/health.py
+++ b/src/alphamind/api/routes/health.py
@@ -1,0 +1,48 @@
+"""Liveness and readiness probes.
+
+``/healthz`` is liveness — it answers "is this process up?" and is
+deliberately cheap (no I/O). Kubernetes / load balancers use this to
+decide whether to restart the pod.
+
+``/readyz`` is readiness — it answers "is this process able to serve
+requests?" by checking Postgres reachability. A returning-from-cold
+process should fail readiness until the DB connection works.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Response
+from sqlalchemy import text
+
+from alphamind.api.schemas import HealthResponse
+from alphamind.db.session import session_scope
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/healthz", response_model=HealthResponse, summary="Liveness probe.")
+async def healthz() -> HealthResponse:
+    return HealthResponse(status="ok")
+
+
+@router.get(
+    "/readyz",
+    response_model=HealthResponse,
+    summary="Readiness probe — verifies Postgres is reachable.",
+)
+async def readyz(response: Response) -> HealthResponse:
+    try:
+        async with session_scope() as session:
+            await session.execute(text("SELECT 1"))
+    except Exception as exc:
+        logger.warning("readyz: database check failed: %s", exc)
+        response.status_code = 503
+        return HealthResponse(status="down", detail=f"database unreachable: {exc}")
+    return HealthResponse(status="ok")
+
+
+__all__ = ["router"]

--- a/src/alphamind/api/routes/research.py
+++ b/src/alphamind/api/routes/research.py
@@ -1,0 +1,61 @@
+"""POST /research — agent-graph streaming endpoint.
+
+The handler validates the request, builds a :class:`GraphInput`, and
+returns a Server-Sent Event stream that emits one event per graph node
+as it completes. The order is router → specialists (in completion
+order, possibly parallel) → synthesizer → critic → ``done``.
+
+The synthesizer's final answer arrives as a single ``thesis`` event,
+not token-by-token. Token streaming requires growing the
+:class:`alphamind.llm.base.LLMClient` protocol with a streaming
+method; that lands in a follow-up.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sse_starlette.sse import EventSourceResponse
+
+from alphamind.agents.graph import ResearchGraph
+from alphamind.agents.state import GraphInput
+from alphamind.api.dependencies import get_research_graph_dep
+from alphamind.api.schemas import ResearchRequest
+from alphamind.api.sse import stream_research
+
+router = APIRouter(tags=["research"])
+
+
+@router.post(
+    "/research",
+    summary="Run the agent graph and stream progress as Server-Sent Events.",
+    responses={
+        200: {
+            "description": (
+                "text/event-stream of SSE events: router-decision, "
+                "specialist-report (one per specialist), thesis, "
+                "critic-report, then done."
+            ),
+            "content": {"text/event-stream": {}},
+        }
+    },
+)
+async def post_research(
+    request: ResearchRequest,
+    # ``Depends(...)`` in argument defaults is the FastAPI idiom — the
+    # framework reads the call expression itself, not the result. B008
+    # is the general "no function calls in defaults" rule and doesn't
+    # know about FastAPI's signature inspection.
+    graph: ResearchGraph = Depends(get_research_graph_dep),  # noqa: B008
+) -> EventSourceResponse:
+    payload = GraphInput(
+        query=request.query,
+        as_of=request.as_of,
+        top_k=request.top_k,
+    )
+    # ``EventSourceResponse`` consumes the async iterator and writes
+    # ``event:``/``data:`` framing for us. It also handles client
+    # disconnects by cancelling the generator.
+    return EventSourceResponse(stream_research(graph, payload))
+
+
+__all__ = ["router"]

--- a/src/alphamind/api/schemas.py
+++ b/src/alphamind/api/schemas.py
@@ -1,0 +1,192 @@
+"""Pydantic request / response models for the HTTP surface.
+
+These are deliberately separate from the dataclasses in
+:mod:`alphamind.agents.state`. The agent layer's dataclasses are an
+internal transport optimised for immutability and Python ergonomics;
+the API schemas are an external contract optimised for JSON
+serialisation, validation, and documentation (FastAPI's OpenAPI
+generator reads these).
+
+Conversion happens at the boundary — :func:`event_payload_from_update`
+in :mod:`alphamind.api.sse` builds these schemas from agent dataclasses
+just before they go on the wire.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+from alphamind.agents.state import (
+    Citation,
+    Claim,
+    CriticReport,
+    RouterDecision,
+    SpecialistName,
+    SpecialistReport,
+    Thesis,
+    UnsupportedClaim,
+)
+
+
+class ResearchRequest(BaseModel):
+    """POST /research body."""
+
+    query: str = Field(min_length=1, description="The research question.")
+    as_of: date = Field(
+        description=(
+            "Time horizon (YYYY-MM-DD). No filings dated after this are "
+            "used. Required, never defaulted — see ADR 0005."
+        ),
+    )
+    top_k: int = Field(
+        default=8,
+        ge=1,
+        le=50,
+        description="Sources fed to each specialist.",
+    )
+
+    @field_validator("query")
+    @classmethod
+    def _strip_query(cls, value: str) -> str:
+        # Trim and reject whitespace-only input that survived ``min_length=1``.
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("query must contain non-whitespace characters")
+        return stripped
+
+
+# --- SSE event payloads ------------------------------------------------------
+
+
+class CitationPayload(BaseModel):
+    """Mirrors :class:`Citation` for the wire."""
+
+    ordinal: int
+    chunk_id: int
+    filing_id: int
+    ticker: str
+    form: str
+    filing_date: date
+    section: str | None
+    text: str
+
+    @classmethod
+    def from_dataclass(cls, c: Citation) -> CitationPayload:
+        return cls(
+            ordinal=c.ordinal,
+            chunk_id=c.chunk_id,
+            filing_id=c.filing_id,
+            ticker=c.ticker,
+            form=c.form,
+            filing_date=c.filing_date,
+            section=c.section,
+            text=c.text,
+        )
+
+
+class ClaimPayload(BaseModel):
+    text: str
+    citations: list[int]
+
+    @classmethod
+    def from_dataclass(cls, c: Claim) -> ClaimPayload:
+        return cls(text=c.text, citations=list(c.citations))
+
+
+class RouterDecisionPayload(BaseModel):
+    specialists: list[SpecialistName]
+    rationale: str
+
+    @classmethod
+    def from_dataclass(cls, d: RouterDecision) -> RouterDecisionPayload:
+        return cls(specialists=list(d.specialists), rationale=d.rationale)
+
+
+class SpecialistReportPayload(BaseModel):
+    specialist: SpecialistName
+    summary: str
+    claims: list[ClaimPayload]
+    citations: list[CitationPayload]
+
+    @classmethod
+    def from_dataclass(cls, r: SpecialistReport) -> SpecialistReportPayload:
+        return cls(
+            specialist=r.specialist,
+            summary=r.summary,
+            claims=[ClaimPayload.from_dataclass(c) for c in r.claims],
+            citations=[CitationPayload.from_dataclass(c) for c in r.citations],
+        )
+
+
+class ThesisPayload(BaseModel):
+    answer: str
+    bull: list[str]
+    bear: list[str]
+    citations: list[CitationPayload]
+
+    @classmethod
+    def from_dataclass(cls, t: Thesis) -> ThesisPayload:
+        return cls(
+            answer=t.answer,
+            bull=list(t.bull),
+            bear=list(t.bear),
+            citations=[CitationPayload.from_dataclass(c) for c in t.citations],
+        )
+
+
+class UnsupportedClaimPayload(BaseModel):
+    claim: str
+    reason: str
+
+    @classmethod
+    def from_dataclass(cls, u: UnsupportedClaim) -> UnsupportedClaimPayload:
+        return cls(claim=u.claim, reason=u.reason)
+
+
+class CriticReportPayload(BaseModel):
+    unsupported: list[UnsupportedClaimPayload]
+    notes: str
+    ok: bool
+
+    @classmethod
+    def from_dataclass(cls, r: CriticReport) -> CriticReportPayload:
+        return cls(
+            unsupported=[UnsupportedClaimPayload.from_dataclass(u) for u in r.unsupported],
+            notes=r.notes,
+            ok=r.ok,
+        )
+
+
+class ErrorPayload(BaseModel):
+    """Final SSE event when the graph itself raised."""
+
+    message: str
+
+
+# --- Health -----------------------------------------------------------------
+
+
+HealthStatus = Literal["ok", "degraded", "down"]
+
+
+class HealthResponse(BaseModel):
+    status: HealthStatus
+    detail: str | None = None
+
+
+__all__ = [
+    "CitationPayload",
+    "ClaimPayload",
+    "CriticReportPayload",
+    "ErrorPayload",
+    "HealthResponse",
+    "HealthStatus",
+    "ResearchRequest",
+    "RouterDecisionPayload",
+    "SpecialistReportPayload",
+    "ThesisPayload",
+    "UnsupportedClaimPayload",
+]

--- a/src/alphamind/api/sse.py
+++ b/src/alphamind/api/sse.py
@@ -1,0 +1,126 @@
+"""Convert agent-graph updates into Server-Sent Event payloads.
+
+LangGraph emits ``(node_name, state_update)`` pairs as each node
+completes. The SSE protocol wants ``{event, data}`` dicts where
+``data`` is a string (JSON-encoded). This module is the seam between
+the two — kept separate from the route handler so the conversion
+logic can be unit-tested without spinning up FastAPI.
+
+Event types (kebab-cased to match HTTP conventions; the ``event:``
+header is what JavaScript ``EventSource`` keys handlers off):
+
+- ``router-decision`` — fired once after the router runs.
+- ``specialist-report`` — fired once per specialist, in completion
+  order (parallel branches resolve in the order they finish).
+- ``thesis`` — fired once after the synthesizer.
+- ``critic-report`` — fired once after the critic.
+- ``error`` — terminal; the graph raised.
+- ``done`` — terminal sentinel so clients know the stream is closed
+  cleanly. Useful for distinguishing "stream ended" from "connection
+  dropped."
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator, Iterable
+from typing import Any
+
+from alphamind.agents.graph import ResearchGraph
+from alphamind.agents.state import (
+    CriticReport,
+    GraphInput,
+    RouterDecision,
+    SpecialistReport,
+    Thesis,
+)
+from alphamind.api.schemas import (
+    CriticReportPayload,
+    ErrorPayload,
+    RouterDecisionPayload,
+    SpecialistReportPayload,
+    ThesisPayload,
+)
+
+logger = logging.getLogger(__name__)
+
+
+SSEEvent = dict[str, str]
+
+
+def _event(name: str, payload: Any) -> SSEEvent:
+    """Build a Server-Sent Event dict.
+
+    ``sse-starlette`` reads ``event`` and ``data`` keys. ``data`` must
+    be a string; pydantic models JSON-encode via ``model_dump_json()``.
+    """
+
+    return {
+        "event": name,
+        "data": payload.model_dump_json() if hasattr(payload, "model_dump_json") else str(payload),
+    }
+
+
+def _events_for_update(node_name: str, state_update: dict[str, Any]) -> Iterable[SSEEvent]:
+    """Yield zero or more SSE events for one LangGraph state-update."""
+
+    # Router writes ``router_decision``.
+    decision = state_update.get("router_decision")
+    if isinstance(decision, RouterDecision):
+        yield _event("router-decision", RouterDecisionPayload.from_dataclass(decision))
+
+    # Specialists append to ``specialist_reports`` (one item per emit).
+    reports = state_update.get("specialist_reports")
+    if isinstance(reports, list):
+        for report in reports:
+            if isinstance(report, SpecialistReport):
+                yield _event(
+                    "specialist-report",
+                    SpecialistReportPayload.from_dataclass(report),
+                )
+
+    # Synthesizer writes ``thesis``.
+    thesis = state_update.get("thesis")
+    if isinstance(thesis, Thesis):
+        yield _event("thesis", ThesisPayload.from_dataclass(thesis))
+
+    # Critic writes ``critic_report``.
+    critic = state_update.get("critic_report")
+    if isinstance(critic, CriticReport):
+        yield _event("critic-report", CriticReportPayload.from_dataclass(critic))
+
+    # Node names that emit nothing (or only fields we already handled)
+    # are silently swallowed. Keep them noted for debugging.
+    if not any(
+        key in state_update
+        for key in ("router_decision", "specialist_reports", "thesis", "critic_report")
+    ):
+        logger.debug("no SSE event derived from node %r update %r", node_name, state_update)
+
+
+async def stream_research(
+    graph: ResearchGraph,
+    payload: GraphInput,
+) -> AsyncIterator[SSEEvent]:
+    """Drive the graph and yield SSE events.
+
+    On unexpected failure, emits a final ``error`` event with the
+    message and exits cleanly. Individual node failures are already
+    handled inside the graph (each node has a fallback path); this
+    catch is for the *graph itself* raising — which currently only
+    happens for input-validation bugs that escape the route layer.
+    """
+
+    try:
+        async for node_name, state_update in graph.stream_updates(payload):
+            for event in _events_for_update(node_name, state_update):
+                yield event
+    except Exception as exc:
+        logger.exception("research graph raised")
+        yield _event("error", ErrorPayload(message=str(exc)))
+        return
+
+    yield {"event": "done", "data": "{}"}
+
+
+__all__ = ["SSEEvent", "stream_research"]

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -1,0 +1,71 @@
+"""Shared fixtures for the API test suite.
+
+The API tests run against a real FastAPI app, but the underlying
+:class:`ResearchGraph` is replaced with a stub that yields canned
+``(node_name, state_update)`` pairs. This keeps the tests focused on
+the HTTP / SSE surface — graph correctness is covered in
+:mod:`tests.unit.agents`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterable, Sequence
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from alphamind.agents.state import GraphInput
+from alphamind.api.app import create_app
+from alphamind.api.dependencies import get_research_graph_dep
+
+
+class StubResearchGraph:
+    """Drop-in for :class:`ResearchGraph`. Yields canned updates."""
+
+    def __init__(self, updates: Sequence[tuple[str, dict[str, Any]]]) -> None:
+        self._updates = list(updates)
+        self.last_payload: GraphInput | None = None
+
+    async def stream_updates(
+        self,
+        payload: GraphInput,
+    ) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+        self.last_payload = payload
+        for node_name, state_update in self._updates:
+            yield node_name, state_update
+
+
+def build_app(
+    stub_updates: Iterable[tuple[str, dict[str, Any]]],
+) -> tuple[FastAPI, StubResearchGraph]:
+    """Build an app with a stub graph injected via dependency override.
+
+    Returns ``(app, stub)`` so tests can inspect the captured payload
+    after the request runs.
+    """
+
+    app = create_app()
+    stub = StubResearchGraph(list(stub_updates))
+    app.dependency_overrides[get_research_graph_dep] = lambda: stub
+    return app, stub
+
+
+@pytest.fixture
+def asgi_transport_factory() -> Any:
+    """Return a helper that wraps ``AsyncClient`` around a FastAPI app.
+
+    Using ``ASGITransport`` skips uvicorn entirely — the requests are
+    handled in-process. Lifespan still runs (so app.state is populated)
+    because ``AsyncClient(transport=...)`` triggers startup / shutdown
+    around its context manager.
+    """
+
+    def _factory(app: FastAPI) -> AsyncClient:
+        return AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        )
+
+    return _factory

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -1,0 +1,65 @@
+"""Tests for /healthz and /readyz."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+
+from alphamind.api.routes import health as health_module
+from tests.unit.api.conftest import build_app
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_healthz_returns_ok(asgi_transport_factory: Any) -> None:
+    app, _ = build_app([])
+    async with asgi_transport_factory(app) as client:
+        response = await client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "detail": None}
+
+
+async def test_readyz_ok_when_db_reachable(
+    monkeypatch: pytest.MonkeyPatch,
+    asgi_transport_factory: Any,
+) -> None:
+    class _FakeSession:
+        async def execute(self, _stmt: Any) -> None:
+            return None
+
+    @asynccontextmanager
+    async def fake_scope() -> Any:
+        yield _FakeSession()
+
+    monkeypatch.setattr(health_module, "session_scope", fake_scope)
+
+    app, _ = build_app([])
+    async with asgi_transport_factory(app) as client:
+        response = await client.get("/readyz")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+async def test_readyz_503_when_db_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+    asgi_transport_factory: Any,
+) -> None:
+    @asynccontextmanager
+    async def fake_scope() -> Any:
+        raise RuntimeError("db down")
+        yield  # pragma: no cover — unreachable, satisfies the generator contract
+
+    monkeypatch.setattr(health_module, "session_scope", fake_scope)
+
+    app, _ = build_app([])
+    async with asgi_transport_factory(app) as client:
+        response = await client.get("/readyz")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "down"
+    assert "db down" in body["detail"]

--- a/tests/unit/api/test_research.py
+++ b/tests/unit/api/test_research.py
@@ -1,0 +1,228 @@
+"""Tests for POST /research.
+
+These tests run the FastAPI app in-process via httpx ``ASGITransport``
+and replace the agent graph with :class:`StubResearchGraph` so the
+HTTP / SSE layer is the only thing under test. Graph correctness is
+covered in :mod:`tests.unit.agents`.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any
+
+import pytest
+
+from alphamind.agents.state import (
+    Citation,
+    Claim,
+    CriticReport,
+    RouterDecision,
+    SpecialistReport,
+    Thesis,
+    UnsupportedClaim,
+)
+from alphamind.api.app import create_app
+from alphamind.api.dependencies import get_research_graph_dep
+from tests.unit.api.conftest import build_app
+
+pytestmark = pytest.mark.asyncio
+
+
+def _citation(ordinal: int, chunk_id: int) -> Citation:
+    return Citation(
+        ordinal=ordinal,
+        chunk_id=chunk_id,
+        filing_id=chunk_id * 10,
+        ticker="NVDA",
+        form="10-K",
+        filing_date=date(2024, 1, 1),
+        section="Item 7",
+        text=f"source-{chunk_id}",
+    )
+
+
+def _parse_sse(body: str) -> list[tuple[str, dict[str, Any]]]:
+    """Parse an SSE response body into ``(event, data)`` pairs.
+
+    SSE framing: a record is one or more ``field: value`` lines
+    separated by blank lines. ``data`` lines concatenate. ``event``
+    defaults to ``message`` when absent.
+    """
+
+    events: list[tuple[str, dict[str, Any]]] = []
+    current_event: str | None = None
+    data_lines: list[str] = []
+
+    def _flush() -> None:
+        if current_event is None and not data_lines:
+            return
+        raw = "\n".join(data_lines).strip()
+        payload: dict[str, Any] = json.loads(raw) if raw else {}
+        events.append((current_event or "message", payload))
+
+    for line in body.splitlines():
+        if not line.strip():
+            _flush()
+            current_event = None
+            data_lines = []
+            continue
+        if line.startswith(":"):  # SSE comments
+            continue
+        if line.startswith("event:"):
+            current_event = line[len("event:") :].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[len("data:") :].lstrip())
+
+    _flush()
+    return events
+
+
+async def test_research_streams_all_node_events(asgi_transport_factory: Any) -> None:
+    citation = _citation(1, 42)
+    router_update = {
+        "router_decision": RouterDecision(specialists=("fundamentals",), rationale="r"),
+    }
+    updates: list[tuple[str, dict[str, Any]]] = [
+        ("router", router_update),
+        (
+            "fundamentals",
+            {
+                "specialist_reports": [
+                    SpecialistReport(
+                        specialist="fundamentals",
+                        summary="data center is huge",
+                        claims=(Claim(text="DC grew 86%", citations=(1,)),),
+                        citations=(citation,),
+                    )
+                ]
+            },
+        ),
+        (
+            "synthesizer",
+            {
+                "thesis": Thesis(
+                    answer="DC growth dominates [1].",
+                    bull=("DC grew 86% [1].",),
+                    bear=(),
+                    citations=(citation,),
+                )
+            },
+        ),
+        (
+            "critic",
+            {
+                "critic_report": CriticReport(
+                    unsupported=(UnsupportedClaim(claim="x", reason="y"),),
+                    notes="one flag",
+                )
+            },
+        ),
+    ]
+    app, stub = build_app(updates)
+
+    async with asgi_transport_factory(app) as client:
+        response = await client.post(
+            "/research",
+            json={"query": "NVDA bull/bear", "as_of": "2024-12-31", "top_k": 5},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+
+    events = _parse_sse(response.text)
+    event_names = [name for name, _ in events]
+    assert event_names == [
+        "router-decision",
+        "specialist-report",
+        "thesis",
+        "critic-report",
+        "done",
+    ]
+
+    # Payloads carry the full state — router-decision has the rationale,
+    # specialist-report carries claims + citations, thesis has bull/bear,
+    # critic-report flags ok=False because there's an unsupported claim.
+    assert events[0][1]["rationale"] == "r"
+    assert events[1][1]["specialist"] == "fundamentals"
+    assert events[1][1]["claims"][0]["text"] == "DC grew 86%"
+    assert events[2][1]["bull"] == ["DC grew 86% [1]."]
+    assert events[3][1]["ok"] is False
+
+    # The stub captured the GraphInput we sent.
+    assert stub.last_payload is not None
+    assert stub.last_payload.query == "NVDA bull/bear"
+    assert stub.last_payload.as_of == date(2024, 12, 31)
+    assert stub.last_payload.top_k == 5
+
+
+async def test_research_rejects_blank_query(asgi_transport_factory: Any) -> None:
+    app, _ = build_app([])
+    async with asgi_transport_factory(app) as client:
+        response = await client.post(
+            "/research",
+            json={"query": "   ", "as_of": "2024-12-31"},
+        )
+
+    # Pydantic field validator should reject whitespace-only queries.
+    assert response.status_code == 422
+
+
+async def test_research_rejects_missing_as_of(asgi_transport_factory: Any) -> None:
+    app, _ = build_app([])
+    async with asgi_transport_factory(app) as client:
+        response = await client.post("/research", json={"query": "ok"})
+    assert response.status_code == 422
+
+
+async def test_research_rejects_negative_top_k(asgi_transport_factory: Any) -> None:
+    app, _ = build_app([])
+    async with asgi_transport_factory(app) as client:
+        response = await client.post(
+            "/research",
+            json={"query": "ok", "as_of": "2024-12-31", "top_k": 0},
+        )
+    assert response.status_code == 422
+
+
+class _ExplodingGraph:
+    """Yields one event then raises — drives the SSE error-event path."""
+
+    async def stream_updates(self, _payload: Any) -> Any:
+        yield (
+            "router",
+            {"router_decision": RouterDecision(specialists=("fundamentals",), rationale="r")},
+        )
+        raise RuntimeError("boom")
+
+
+def _exploding_graph() -> _ExplodingGraph:
+    return _ExplodingGraph()
+
+
+async def test_research_emits_error_event_when_graph_raises(
+    asgi_transport_factory: Any,
+) -> None:
+    # An empty updates list means the stub yields nothing — but the
+    # graph runs to completion successfully. For an error path we need
+    # a stub that raises mid-stream.
+    app = create_app()
+    app.dependency_overrides[get_research_graph_dep] = _exploding_graph
+
+    async with asgi_transport_factory(app) as client:
+        response = await client.post(
+            "/research",
+            json={"query": "ok", "as_of": "2024-12-31"},
+        )
+
+    assert response.status_code == 200
+    events = _parse_sse(response.text)
+    event_names = [name for name, _ in events]
+    # Router event makes it out before the failure, then the error
+    # event lands and the stream ends without a 'done' sentinel.
+    assert event_names[0] == "router-decision"
+    assert "error" in event_names
+    assert "done" not in event_names
+    error_event = next(payload for name, payload in events if name == "error")
+    assert "boom" in error_event["message"]

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "asyncpg" },
     { name = "beautifulsoup4" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "langgraph" },
     { name = "lxml" },
@@ -38,8 +39,10 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "redis" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "sse-starlette" },
     { name = "tenacity" },
     { name = "tiktoken" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.optional-dependencies]
@@ -64,6 +67,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40" },
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "beautifulsoup4", specifier = ">=4.12" },
+    { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "langgraph", specifier = ">=0.2.50" },
     { name = "lxml", specifier = ">=5.3" },
@@ -74,8 +78,10 @@ requires-dist = [
     { name = "redis", specifier = ">=5.2" },
     { name = "sentence-transformers", marker = "extra == 'rerank'", specifier = ">=3.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+    { name = "sse-starlette", specifier = ">=2.1" },
     { name = "tenacity", specifier = ">=9.0" },
     { name = "tiktoken", specifier = ">=0.8" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
 provides-extras = ["rerank"]
 
@@ -538,6 +544,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -664,6 +686,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375, upload-time = "2025-10-10T03:54:31.941Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621, upload-time = "2025-10-10T03:54:33.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", size = 454954, upload-time = "2025-10-10T03:54:34.226Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", size = 440175, upload-time = "2025-10-10T03:54:35.942Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", size = 440310, upload-time = "2025-10-10T03:54:37.1Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", size = 86875, upload-time = "2025-10-10T03:54:38.421Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
 ]
 
 [[package]]
@@ -2457,6 +2515,32 @@ asyncio = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2865,6 +2949,68 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677, upload-time = "2025-10-16T22:16:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819, upload-time = "2025-10-16T22:16:23.903Z" },
+    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", size = 3804529, upload-time = "2025-10-16T22:16:25.246Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", size = 3621267, upload-time = "2025-10-16T22:16:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", size = 3723105, upload-time = "2025-10-16T22:16:28.252Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "21.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2877,6 +3023,169 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/3d/8024c801df84d1587740d0359e7fdd80afeae3d159011f3d5376dd82f18e/watchfiles-1.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:704fd259e332e01f9b9c178f4bce9e49027e5587cc2600eeeaf8e76e1c846201", size = 400242, upload-time = "2026-05-18T04:31:19.014Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/f4dfd45323e949984a3a7f9dc31d1cbb049921e7d98253488dda72ccdaa9/watchfiles-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6543cf55d170003296d185c0af981f3e1311564907e1f4e08671fc7693a890a5", size = 394562, upload-time = "2026-05-18T04:30:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d8/19483ef075d601c409bce8bcbb5c0f81a10876fff870400568f08ce484a1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d8c2394a065ca86f5d2910ff263ae67c127e1376ccc4f9fc35c71db879f80a", size = 456611, upload-time = "2026-05-18T04:30:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6a/cc81fbe7ee42f2f22e661a6e12def7807e01b14b2f39e0ff83fd373fd307/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:772b80df316480d894a0e3165fdd19cf77f5d17f9a787f94029465ad0e3529d1", size = 461379, upload-time = "2026-05-18T04:31:29.292Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/57/7e669002082c0a0f4fb5113bb70125f7110124b846b0a11bc5ae8e90eac1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d158cd89df6053823533e06fb1d73c549133bff5f0396170c0e53d9559340717", size = 493556, upload-time = "2026-05-18T04:30:05.44Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/f60a2b19807b21fe8281f3a8da4f59eef0d5f96825ac4680ba2d4f2ebf91/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d516b3283a758e087841aedb8031549fb41ced08f3db10aa6d2bf32dc042525b", size = 575255, upload-time = "2026-05-18T04:30:40.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/49/77f5b5e6efbcd57482f74948ebb1b97e5c0046d6b61475042d830c84b3ff/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53b2290c92e0506d102cd448fbc610d87079553f86caa39d67440856a8b8bba5", size = 467052, upload-time = "2026-05-18T04:31:17.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5a/73e2959af1b97fd5d556f9a8bdba017be23ceeef731869d5eaa0a753d5a3/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a711b51aec4370d0dcda5b6c09463206f133a5759341d7744b953a7b62e1100e", size = 456858, upload-time = "2026-05-18T04:30:30.182Z" },
+    { url = "https://files.pythonhosted.org/packages/50/57/1bc8c27fad7e6c19bddee15d276dbb6ab72480ec01c127afff1673aee417/watchfiles-1.2.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:e2ca07fa7d89195ec0865d3d285666286740bfa83d83e5cee204043a31ecc165", size = 467579, upload-time = "2026-05-18T04:32:15.897Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6c/3c2e44edba3553c5e3c3b8c8a2a6dee6b9e12ae2cf4bd2378bebf9dc3038/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e0618518f282c4ebff60f5e5b1247b6d91bb8b9f4476947563a1e74acc66f3c6", size = 633253, upload-time = "2026-05-18T04:31:37.123Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c2/d8c84a882ab39bbefcc4915ab3e91830b7a7e990c5570b0b69075aba3faf/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0d191c054d0715c3c95c99df9b8dbf6fd096d8c1e021e8f212e1bd8bc444ccb5", size = 660713, upload-time = "2026-05-18T04:31:24.62Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/07/f97736a5fc605364fe67b25e9fa4a6965dfd4840d50c406ada507e9d735f/watchfiles-1.2.0-cp311-cp311-win32.whl", hash = "sha256:9342472aff9b093c5acd4f6d8f70ae0937964ab56542502bcf5579782da69ae8", size = 277222, upload-time = "2026-05-18T04:31:21.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/99/2b04981977fc2608afd60360d928c6aecf6b950292ca221d98f4005f6694/watchfiles-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:dbd6c97045dad81227c8d040173da044c1de08de64a5ea8b555da4aee1d5fa22", size = 290274, upload-time = "2026-05-18T04:31:45.966Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/74/f7f58a7075ee9cf612b0cfcddb78b8cd8234f0742d6f0075cf0da2dde1c6/watchfiles-1.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:57a2d9fa4fb4c2ecae57b13dfff2c7ab53e21a2ba674fe9f05506680fcdcc0d7", size = 283460, upload-time = "2026-05-18T04:31:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f4/7513ef1e85fc4c6331b59479d6d72661fc391fbe543678052ac72c8b6c19/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4674d49eb94706dfe666c069fc0a1b646ffcf920473492e209f6d5f60d3f0cc2", size = 403050, upload-time = "2026-05-18T04:30:36.753Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0b/a54103cfd732bb703c7a749222011a0483ef3705948dae3b203158601119/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:094b9b70103d4e963499bdea001ee3c2697b144cd9ae6218a62c0f89ec9e31db", size = 396629, upload-time = "2026-05-18T04:32:03.268Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2c/73f31a3b893886206c3f54d73e8ad8dee58cdb2f69ad2622e0a8a9e07f4e/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0ef001f8c25ad0fa9529f914c1600647ecd0f542d11c19b7894768c67b6acb7", size = 457318, upload-time = "2026-05-18T04:31:01.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/45d021e4a5cc7b9dd567f7cbb06d3b75f751a690063fb6cc7ec60f4e46b7/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a88fc94e647bc4eec523f1caa540258eb71d14278b9daf72fa1e2658a98df0f0", size = 457771, upload-time = "2026-05-18T04:30:56.331Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on top of [#17](https://github.com/Nishchal45/alphamind/pull/17). Rebase / re-target to `main` once that merges. Independent of [#18](https://github.com/Nishchal45/alphamind/pull/18) — both can land in either order.

## Summary

- Adds `alphamind.api`, a FastAPI app with a streaming research endpoint and k8s-shaped health probes.
- `POST /research` runs the agent graph and streams progress as Server-Sent Events: `router-decision`, one `specialist-report` per specialist in completion order, `thesis`, `critic-report`, then a `done` sentinel (or `error` on graph failure).
- `GET /healthz` is liveness with no I/O. `GET /readyz` pings Postgres and returns `503` if unreachable.
- `ResearchGraph.stream_updates()` is the new agent-layer surface — yields `(node_name, state_update)` pairs from LangGraph's `astream(stream_mode="updates")`. Keeps LangGraph internals out of the API code.
- Pydantic schemas mirror the agent dataclasses at the boundary; conversion is one `from_dataclass` per type. Separate by design ([ADR 0008](docs/adr/0008-fastapi-serving-and-sse.md) explains why).
- `make serve` target runs uvicorn with autoreload against `create_app()`.
- **What's NOT in this slice**: token-level streaming of the synthesizer answer (needs LLMClient protocol growth), Redis cache, cost routing, auth. Each is called out as deferred in ADR 0008.

## Test plan

- [x] `make ci` — ruff check + format check, mypy strict (116 files), 172 unit tests (8 new in `tests/unit/api/`)
- [x] App routes register correctly (`/healthz`, `/readyz`, `/research`, `/docs`)
- [x] SSE event parser test asserts the full event order and payloads end-to-end
- [x] Input validation rejects blank queries, missing `as_of`, out-of-range `top_k`
- [x] `error` event fires when the graph raises mid-stream; `done` does not
- [ ] Manually run `make serve` and `curl -N -X POST http://localhost:8000/research ...` against ingested data with `LLM_BACKEND=anthropic` to verify the live stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)